### PR TITLE
Added outOfBandRecord and  reuseThreadId in connection record for reuse-connection event.

### DIFF
--- a/apps/api-gateway/src/connection/dtos/connection.dto.ts
+++ b/apps/api-gateway/src/connection/dtos/connection.dto.ts
@@ -206,6 +206,14 @@ export class ConnectionDto {
     @ApiPropertyOptional()
     @IsOptional()
     type: string;
+
+    @ApiPropertyOptional()
+    @IsOptional()
+    outOfBandRecord?: object;
+
+    @ApiPropertyOptional()
+    @IsOptional()
+    reuseThreadId?: string;
 }
 
 class ReceiveInvitationCommonDto {


### PR DESCRIPTION
# What?
- Added outOfBandRecord and reuseThreadId in connection record for reuse-connection event.

#Why
- To make reuse-connection work.