### PR TITLE
fix: added parentThreadId in webhook response of proof request

### DIFF
--- a/apps/api-gateway/src/verification/dto/webhook-proof.dto.ts
+++ b/apps/api-gateway/src/verification/dto/webhook-proof.dto.ts
@@ -43,6 +43,10 @@ export class WebhookPresentationProofDto {
 
     @ApiPropertyOptional()
     @IsOptional()
+    parentThreadId?: string;
+
+    @ApiPropertyOptional()
+    @IsOptional()
     presentationId: string;
 
     @ApiPropertyOptional()

--- a/apps/verification/src/interfaces/verification.interface.ts
+++ b/apps/verification/src/interfaces/verification.interface.ts
@@ -206,6 +206,7 @@ export interface IWebhookProofPresentation {
     connectionId: string;
     presentationId: string;
     threadId: string;
+    parentThreadId?: string;
     autoAcceptProof: string;
     updatedAt: string;
     isVerified: boolean;


### PR DESCRIPTION
what?
added parentThreadId in webhook response of proof request

why?
Since it was not present in DTO and we want it to use for proofRequest
