### PR TITLE
fix: added parentThreadId which was missed in proof creation payload to agent

### DIFF
--- a/apps/verification/src/verification.service.ts
+++ b/apps/verification/src/verification.service.ts
@@ -379,6 +379,7 @@ export class VerificationService {
           url,
           proofRequestPayload: {
             goalCode: outOfBandRequestProof.goalCode,
+            parentThreadId: outOfBandRequestProof.parentThreadId,
             protocolVersion:outOfBandRequestProof.protocolVersion || 'v2',
             comment:outOfBandRequestProof.comment,
             label,


### PR DESCRIPTION
fix: added parentThreadId which was missed in proof creation payload to agent