### PR TITLE
add filter support to presentation definition constraints

### DIFF
--- a/apps/agent-service/src/interface/agent-service.interface.ts
+++ b/apps/agent-service/src/interface/agent-service.interface.ts
@@ -343,8 +343,14 @@ export interface IAgentStatus {
 export interface ISchema {
   uri: string;
 }
+
+export interface IFilter {
+  type: string;
+  pattern: string;
+}
 export interface IFields {
   path: string[];
+  filter: IFilter;
 }
 export interface IConstraints {
   fields: IFields[];

--- a/apps/api-gateway/src/verification/dto/request-proof.dto.ts
+++ b/apps/api-gateway/src/verification/dto/request-proof.dto.ts
@@ -69,11 +69,29 @@ class ProofPayload {
     protocolVersion: string;
 }
 
+export class Filter {
+  @ApiProperty()
+  @IsString({ message: 'type must be in string' })
+  @IsNotEmpty({ message: 'type is required.' })
+  type: string;
+
+  @ApiProperty()
+  @IsString({ message: 'pattern must be in string' })
+  @IsNotEmpty({ message: 'pattern is required.' })
+  pattern: string;
+}
 export class Fields {
   @ApiProperty()
   @IsArray()
   @IsNotEmpty({ message: 'path is required.' })
   path: string[];
+
+  @ApiProperty()
+  @IsOptional()
+  @IsNotEmpty({ message: 'filter is required.' })
+  @ValidateNested()
+  @Type(() => Filter)
+  filter: Filter;
 }
 
 export class Constraints {
@@ -380,7 +398,11 @@ export class SendProofRequestPayload {
                       'constraints': {
                         'fields': [
                           {
-                            'path': ['$.issuer']
+                            'path': ['$.issuer.id'],
+                            'filter': {
+                              'type': 'string',
+                              'pattern': 'did:example:123|did:example:456'
+                            }
                           }
                         ]
                       }

--- a/apps/verification/src/interfaces/verification.interface.ts
+++ b/apps/verification/src/interfaces/verification.interface.ts
@@ -101,8 +101,14 @@ interface IRequestedRestriction {
 export interface ISchema {
     uri:string;
 }
+
+export interface IFilter {
+    type: string;
+    pattern: string;
+}
 export interface IFields {
     path: string[];
+    filter: IFilter;
   }
 export interface IConstraints {
     fields: IFields[];


### PR DESCRIPTION
- Added filter support for the fields of constraints for input descriptors
- Any filtering constraints of fields can be added for presentation definition 
- Example: Adding filter for issuer DID to accept fields from only selected issuers