### PR TITLE
Fix the query causing huge data response exceeding NATS max payload size

### DIFF
--- a/apps/organization/interfaces/organization.interface.ts
+++ b/apps/organization/interfaces/organization.interface.ts
@@ -61,7 +61,7 @@ interface ISchema {
 }
 
 interface IOrgAgents {
-  agent_invitations: IAgentInvitation[];
+  agent_invitations?: IAgentInvitation[];
   ledgers: ILedgers;
   org_agent_type: IOrgAgentType;
 }

--- a/apps/organization/repositories/organization.repository.ts
+++ b/apps/organization/repositories/organization.repository.ts
@@ -442,13 +442,14 @@ export class OrganizationRepository {
               agentsTypeId: true,
               orgAgentTypeId: true,
               createDateTime: true,
-              agent_invitations: {
-                select: {
-                  id: true,
-                  connectionInvitation: true,
-                  multiUse: true
-                }
-              },
+              // Following returns huge response for exceeding NATS max payload size
+              // agent_invitations: {
+              //   select: {
+              //     id: true,
+              //     connectionInvitation: true,
+              //     multiUse: true
+              //   }
+              // },
               org_agent_type: true,
               ledgers: {
                 select: {


### PR DESCRIPTION
Update the query by deselecting the agent invitation which contains all the connection records thereby increasing the payload size and therefore exceeding NATS max payload size.