### PR TITLE
Fix DB seed and migration. Fix create Schema.

### DIFF
--- a/.github/workflows/qa-seed.yml
+++ b/.github/workflows/qa-seed.yml
@@ -64,7 +64,7 @@ jobs:
         env:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
           ECR_REPOSITORY: qa-services
-          IMAGE_TAG: "SEED_V_$${{ github.run_number }}"
+          IMAGE_TAG: "SEED_V_${{ github.run_number }}"
         run: |
           docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG -f Dockerfiles/Dockerfile.seed .
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
@@ -74,7 +74,7 @@ jobs:
         run: |
           echo "ECR_REGISTRY=${{ steps.login-ecr.outputs.registry }}" >> $GITHUB_ENV
           echo "ECR_REPOSITORY=qa-services" >> $GITHUB_ENV
-          echo "IMAGE_TAG=SEED_V_$${{ github.run_number }}" >> $GITHUB_ENV
+          echo "IMAGE_TAG=SEED_V_${{ github.run_number }}" >> $GITHUB_ENV
    
       - name: Print environment variables
         run: |

--- a/Dockerfiles/Dockerfile.seed
+++ b/Dockerfiles/Dockerfile.seed
@@ -19,6 +19,9 @@ RUN pnpm i --frozen-lockfile
 # Copy the rest of the source code
 COPY . .
 
+# Generate Prisma client
+RUN npx prisma generate --schema=./libs/prisma-service/prisma/schema.prisma
+
 # Stage 2: Create the final, lean production image
 FROM node:18-alpine3.18
 
@@ -31,9 +34,13 @@ WORKDIR /app
 COPY --from=builder /app/package.json ./
 
 # Copy the specific service code and its dependencies from the builder stage
-COPY --from=builder /app/libs/prisma-service ./libs/prisma-service
+COPY --from=builder /app/libs ./libs
 COPY --from=builder /app/node_modules ./node_modules
 
+# Copy tsconfig files for ts-node
+COPY --from=builder /app/tsconfig.json ./
+COPY --from=builder /app/tsconfig.build.json ./
+
 # Set the command to run the seed script
-# This now runs inside a container with the correct dependencies and source code
-CMD ["sh", "-c", "npx prisma migrate deploy --schema=./libs/prisma-service/prisma/schema.prisma && npx prisma db seed"]
+# Generate client again in case of architecture differences, then run migrations and seed
+CMD ["sh", "-c", "npx prisma generate --schema=./libs/prisma-service/prisma/schema.prisma && npx prisma migrate deploy --schema=./libs/prisma-service/prisma/schema.prisma && npx prisma db seed"]

--- a/Dockerfiles/Dockerfile.seed
+++ b/Dockerfiles/Dockerfile.seed
@@ -10,7 +10,7 @@ RUN npm install -g pnpm --ignore-scripts
 WORKDIR /app
 
 # Copy only the files required by pnpm to install dependencies for the entire monorepo
-COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+COPY package.json pnpm-lock.yaml ./
 
 # Install ALL monorepo dependencies based on the lockfile
 # This will install the correct version of Prisma CLI

--- a/Dockerfiles/Dockerfile.seed
+++ b/Dockerfiles/Dockerfile.seed
@@ -36,4 +36,4 @@ COPY --from=builder /app/node_modules ./node_modules
 
 # Set the command to run the seed script
 # This now runs inside a container with the correct dependencies and source code
-CMD ["sh", "-c", "cd libs/prisma-service && npx prisma migrate deploy && npx prisma db seed"]
+CMD ["sh", "-c", "npx prisma migrate deploy --schema=./libs/prisma-service/prisma/schema.prisma && npx prisma db seed"]

--- a/Dockerfiles/Dockerfile.seed
+++ b/Dockerfiles/Dockerfile.seed
@@ -27,6 +27,9 @@ RUN apk add --no-cache --update postgresql-client openssl1.1-compat
 
 WORKDIR /app
 
+# Copy the root package.json so prisma can find its seed configuration
+COPY --from=builder /app/package.json ./
+
 # Copy the specific service code and its dependencies from the builder stage
 COPY --from=builder /app/libs/prisma-service ./libs/prisma-service
 COPY --from=builder /app/node_modules ./node_modules

--- a/Dockerfiles/Dockerfile.seed
+++ b/Dockerfiles/Dockerfile.seed
@@ -1,7 +1,7 @@
 # Stage 1: Build the application
 FROM node:18-alpine as build
 
-RUN apk add --no-cache postgresql-client
+RUN apk add --no-cache postgresql-client openssl1.1-compat
 RUN npm install -g pnpm --ignore-scripts
 WORKDIR /app
 COPY package.json ./

--- a/Dockerfiles/Dockerfile.seed
+++ b/Dockerfiles/Dockerfile.seed
@@ -38,6 +38,9 @@ COPY --from=builder /app/node_modules ./node_modules
 COPY --from=builder /app/tsconfig.json ./
 COPY --from=builder /app/tsconfig.build.json ./
 
+# Create symlink for prisma data files to where seed script expects them
+RUN ln -s /app/libs/prisma-service/prisma /app/prisma
+
 # Set the command to run the seed script
 # Generate client at runtime, then run migrations and seed
 CMD ["sh", "-c", "npx prisma generate --schema=./libs/prisma-service/prisma/schema.prisma && npx prisma migrate deploy --schema=./libs/prisma-service/prisma/schema.prisma && npx prisma db seed"]

--- a/Dockerfiles/Dockerfile.seed
+++ b/Dockerfiles/Dockerfile.seed
@@ -1,7 +1,7 @@
 # Stage 1: Build the application
 FROM node:18-alpine as build
 
-RUN apk update && apk add --no-cache postgresql-client openssl1.1-compat
+RUN apk add --no-cache --update postgresql-client openssl1.1-compat
 RUN npm install -g pnpm --ignore-scripts
 WORKDIR /app
 COPY package.json ./

--- a/Dockerfiles/Dockerfile.seed
+++ b/Dockerfiles/Dockerfile.seed
@@ -1,33 +1,36 @@
-# Stage 1: Build dependencies
+# Stage 1: Build the application with all dependencies
 FROM node:18-alpine3.18 as builder
 
-# Install dependencies required for the build
+# Install OS-level dependencies
 RUN apk add --no-cache --update postgresql-client openssl1.1-compat
+
+# Install pnpm
 RUN npm install -g pnpm --ignore-scripts
 
 WORKDIR /app
 
-# Copy only the files required to install dependencies
-COPY package.json pnpm-lock.yaml ./
-COPY libs/prisma-service/package.json ./libs/prisma-service/
+# Copy only the files required by pnpm to install dependencies for the entire monorepo
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 
 # Install ALL monorepo dependencies based on the lockfile
+# This will install the correct version of Prisma CLI
 RUN pnpm i --frozen-lockfile
 
-# Stage 2: Create the final, lean image
+# Copy the rest of the source code
+COPY . .
+
+# Stage 2: Create the final, lean production image
 FROM node:18-alpine3.18
 
-# Install only runtime dependencies
+# Install only OS-level runtime dependencies
 RUN apk add --no-cache --update postgresql-client openssl1.1-compat
 
 WORKDIR /app
 
-# Copy installed dependencies from the builder stage
-COPY --from=builder /app/node_modules ./node_modules
+# Copy the specific service code and its dependencies from the builder stage
 COPY --from=builder /app/libs/prisma-service ./libs/prisma-service
+COPY --from=builder /app/node_modules ./node_modules
 
-# Copy the prisma schema and scripts
-COPY libs/prisma-service/prisma ./libs/prisma-service/prisma
-
-# Set the command to run the microservice
+# Set the command to run the seed script
+# This now runs inside a container with the correct dependencies and source code
 CMD ["sh", "-c", "cd libs/prisma-service && npx prisma migrate deploy && npx prisma db seed"]

--- a/Dockerfiles/Dockerfile.seed
+++ b/Dockerfiles/Dockerfile.seed
@@ -8,7 +8,7 @@ RUN npm install -g pnpm --ignore-scripts
 WORKDIR /app
 
 # Copy dependency definition files for pnpm
-COPY package.json pnpm-lock.yaml .npmrc ./
+COPY package.json pnpm-lock.yaml ./
 
 # Install ALL monorepo dependencies
 RUN pnpm i --frozen-lockfile

--- a/Dockerfiles/Dockerfile.seed
+++ b/Dockerfiles/Dockerfile.seed
@@ -1,5 +1,6 @@
 # Stage 1: Build the application
-FROM node:18-alpine as build
+FROM node:18-alpine3.18 as build
+#FROM node:18-alpine as build
 
 RUN apk add --no-cache --update postgresql-client openssl1.1-compat
 RUN npm install -g pnpm --ignore-scripts

--- a/Dockerfiles/Dockerfile.seed
+++ b/Dockerfiles/Dockerfile.seed
@@ -1,7 +1,7 @@
 # Stage 1: Build the application
 FROM node:18-alpine as build
 
-RUN apk add --no-cache postgresql-client openssl1.1-compat
+RUN apk update && apk add --no-cache postgresql-client openssl1.1-compat
 RUN npm install -g pnpm --ignore-scripts
 WORKDIR /app
 COPY package.json ./

--- a/Dockerfiles/Dockerfile.seed
+++ b/Dockerfiles/Dockerfile.seed
@@ -1,23 +1,23 @@
 # Stage 1: Build the application
 FROM node:18-alpine3.18 as build
-#FROM node:18-alpine as build
 
+# Install dependencies required for the build
 RUN apk add --no-cache --update postgresql-client openssl1.1-compat
 RUN npm install -g pnpm --ignore-scripts
+
 WORKDIR /app
-COPY package.json ./
 
-# Install dependencies
-RUN pnpm i
+# Copy dependency definition files for pnpm
+COPY package.json pnpm-lock.yaml .npmrc ./
 
+# Install ALL monorepo dependencies
+RUN pnpm i --frozen-lockfile
+
+# Copy the rest of the source code
 COPY . .
 
-
-# Set permissions
-RUN chmod 777 /app/libs/prisma-service/prisma/scripts
-RUN chmod +x /app/libs/prisma-service/prisma/scripts/geo_location_data_import.sh
-RUN chmod +x /app/libs/prisma-service/prisma/scripts/update_client_credential_data.sh
-
+# Set permissions for scripts
+RUN chmod +x /app/libs/prisma-service/prisma/scripts/*.sh
 
 # Set the command to run the microservice
 CMD ["sh", "-c", "cd libs/prisma-service && npx prisma generate && npx prisma migrate deploy && npx prisma db seed"]

--- a/Dockerfiles/Dockerfile.seed
+++ b/Dockerfiles/Dockerfile.seed
@@ -1,5 +1,5 @@
-# Stage 1: Build the application
-FROM node:18-alpine3.18 as build
+# Stage 1: Build dependencies
+FROM node:18-alpine3.18 as builder
 
 # Install dependencies required for the build
 RUN apk add --no-cache --update postgresql-client openssl1.1-compat
@@ -7,17 +7,27 @@ RUN npm install -g pnpm --ignore-scripts
 
 WORKDIR /app
 
-# Copy dependency definition files for pnpm
+# Copy only the files required to install dependencies
 COPY package.json pnpm-lock.yaml ./
+COPY libs/prisma-service/package.json ./libs/prisma-service/
 
-# Install ALL monorepo dependencies
+# Install ALL monorepo dependencies based on the lockfile
 RUN pnpm i --frozen-lockfile
 
-# Copy the rest of the source code
-COPY . .
+# Stage 2: Create the final, lean image
+FROM node:18-alpine3.18
 
-# Set permissions for scripts
-RUN chmod +x /app/libs/prisma-service/prisma/scripts/*.sh
+# Install only runtime dependencies
+RUN apk add --no-cache --update postgresql-client openssl1.1-compat
+
+WORKDIR /app
+
+# Copy installed dependencies from the builder stage
+COPY --from=builder /app/node_modules ./node_modules
+COPY --from=builder /app/libs/prisma-service ./libs/prisma-service
+
+# Copy the prisma schema and scripts
+COPY libs/prisma-service/prisma ./libs/prisma-service/prisma
 
 # Set the command to run the microservice
-CMD ["sh", "-c", "cd libs/prisma-service && npx prisma generate && npx prisma migrate deploy && npx prisma db seed"]
+CMD ["sh", "-c", "cd libs/prisma-service && npx prisma migrate deploy && npx prisma db seed"]

--- a/Dockerfiles/Dockerfile.seed
+++ b/Dockerfiles/Dockerfile.seed
@@ -19,9 +19,6 @@ RUN pnpm i --frozen-lockfile
 # Copy the rest of the source code
 COPY . .
 
-# Generate Prisma client
-RUN npx prisma generate --schema=./libs/prisma-service/prisma/schema.prisma
-
 # Stage 2: Create the final, lean production image
 FROM node:18-alpine3.18
 
@@ -42,5 +39,5 @@ COPY --from=builder /app/tsconfig.json ./
 COPY --from=builder /app/tsconfig.build.json ./
 
 # Set the command to run the seed script
-# Generate client again in case of architecture differences, then run migrations and seed
+# Generate client at runtime, then run migrations and seed
 CMD ["sh", "-c", "npx prisma generate --schema=./libs/prisma-service/prisma/schema.prisma && npx prisma migrate deploy --schema=./libs/prisma-service/prisma/schema.prisma && npx prisma db seed"]

--- a/apps/ledger/src/schema/schema.service.ts
+++ b/apps/ledger/src/schema/schema.service.ts
@@ -314,7 +314,7 @@ export class SchemaService extends BaseService {
       if (schemaPayload.schemaType === JSONSchemaType.POLYGON_W3C || schemaPayload.schemaType === JSONSchemaType.ETHEREUM_W3C) {
         const createSchemaPayload = await this._createW3CSchema(W3cSchemaPayload);
         createSchema = createSchemaPayload.response;
-        createSchema.type = JSONSchemaType.POLYGON_W3C;
+        createSchema.type = schemaPayload.schemaType;
       } else {
         const createSchemaPayload = await this._createW3CledgerAgnostic(schemaObject);
         if (!createSchemaPayload) {

--- a/libs/common/src/common.utils.ts
+++ b/libs/common/src/common.utils.ts
@@ -62,7 +62,7 @@ export function convertUrlToDeepLinkUrl(url: string): string {
 export const networkNamespace = (did: string):string => {
   // Split the DID into segments using the colon as a delimiter
   const segments = did.split(':');
-  const containsTestnet = segments.some(segment => segment.includes('polygon'));
+  const containsTestnet = segments.some(segment => segment.includes('testnet')) || segments.some(segment => segment.includes('sepolia'));
   if (containsTestnet) {
     return `${segments[1]}:${segments[2]}`;
   } else {

--- a/libs/prisma-service/prisma/schema.prisma
+++ b/libs/prisma-service/prisma/schema.prisma
@@ -1,5 +1,6 @@
 generator client {
-  provider = "prisma-client-js"
+provider      = "prisma-client-js"
+binaryTargets = ["native", "linux-musl-openssl-1.1.x"]
 }
 
 datasource db {

--- a/libs/prisma-service/prisma/schema.prisma
+++ b/libs/prisma-service/prisma/schema.prisma
@@ -1,6 +1,6 @@
 generator client {
 provider      = "prisma-client-js"
-binaryTargets = ["native", "linux-musl-openssl-1.1.x"]
+ binaryTargets = ["native", "linux-musl"]
 }
 
 datasource db {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "prepare": "husky install"
   },
   "prisma": {
-    "seed": "ts-node prisma/seed.ts"
+    "seed": "ts-node libs/prisma-service/prisma/seed.ts"
   },
   "dependencies": {
     "@nestjs/axios": "^3.0.0",


### PR DESCRIPTION
1. `Dockerfile.seed:`
- Pinned base image to `node:18-alpine3.18` to ensure `openssl1.1-compat` package availability
- Implemented multi-stage Docker build to optimize image size and build process
- Added proper copying of `package.json` for correct dependency resolution
- Included TypeScript configuration files `tsconfig.json`  to support `ts-node` execution
- Created symlink from `/app/prisma` to `/app/libs/prisma-service/prisma` to resolve seed data file path issues
- Removed build-time Prisma generation to avoid binary target conflicts, moved to runtime generation

2. `package.json:`
- Added `prisma` configuration block with seed command path: `"seed":` `"ts-node [seed.ts](http://_vscodecontentref_/4)"`
- This enables `npx prisma db seed` to locate and execute the correct seed script

3. `schema.prisma:`
- Added binary targets to utilise `["native", "linux-musl"]`, on line 3
- This resolves compatibility with Prisma 5.1.1

4. Fix schema create for ethereum
- Added sepolia testnet check for Ethereum
- Update current testnet check for Polygon