### PR TITLE
feat: migrate w3c schema to ethereum ledger

### DIFF
--- a/apps/agent-service/src/agent-service.controller.ts
+++ b/apps/agent-service/src/agent-service.controller.ts
@@ -78,6 +78,11 @@ export class AgentServiceController {
     return this.agentServiceService.createW3CSchema(payload.url, payload.orgId, payload.schemaRequestPayload);
   }
 
+  @MessagePattern({ cmd: 'agent-migrate-w3c-schema' })
+  async migrateW3CSchema(payload: { url, orgId, schemaRequestPayload }): Promise<object> {
+    return this.agentServiceService.migrateW3CSchema(payload.url, payload.orgId, payload.schemaRequestPayload);
+  }
+
   //DONE
   @MessagePattern({ cmd: 'agent-get-schema' })
   async getSchemaById(payload: IGetSchemaAgentRedirection): Promise<object> {

--- a/apps/agent-service/src/agent-service.service.ts
+++ b/apps/agent-service/src/agent-service.service.ts
@@ -1894,6 +1894,19 @@ export class AgentServiceService {
     }
   }
 
+  async migrateW3CSchema(url: string, orgId: string, schemaRequestPayload): Promise<object> {
+    try {
+      const getApiKey = await this.getOrgAgentApiKey(orgId);
+      const schemaRequest = await this.commonService
+        .httpPost(url, schemaRequestPayload, { headers: { authorization: getApiKey } })
+        .then(async (response) => response);
+      return schemaRequest;
+    } catch (error) {
+      this.logger.error(`Error in migrateW3CSchema request in agent service : ${JSON.stringify(error)}`);
+      throw error;
+    }
+  }
+
   async createConnectionInvitation(
     url: string,
     orgId: string,

--- a/apps/api-gateway/src/dtos/migrate-schema.dto.ts
+++ b/apps/api-gateway/src/dtos/migrate-schema.dto.ts
@@ -1,0 +1,29 @@
+import { Equals, IsNotEmpty, IsString } from 'class-validator';
+
+import { ApiProperty } from '@nestjs/swagger';
+import { Transform } from 'class-transformer';
+import { trim } from '@credebl/common/cast.helper';
+import { JSONSchemaType } from '@credebl/enum/enum';
+
+export class MigrateW3CSchemaDto {
+    
+    @ApiProperty({
+      description: 'The identifier of the schema',
+      example: '12345678-1234-5678-1234-567812345678' 
+    })
+    @IsString()
+    @Transform(({ value }) => trim(value))
+    @IsNotEmpty({ message: 'schemaId is required' })
+    schemaId: string;
+
+    @ApiProperty({
+      description: 'The target schema type (only Ethereum supported)',
+      enum: JSONSchemaType,
+      example: JSONSchemaType.ETHEREUM_W3C 
+    })
+    @Equals(JSONSchemaType.ETHEREUM_W3C, {
+      message: 'Only Ethereum schema type is supported as target for now'
+    })
+    @IsNotEmpty({ message: 'targetSchemaType is required' })
+    targetSchemaType: JSONSchemaType;
+}

--- a/apps/api-gateway/src/dtos/migrate-schema.dto.ts
+++ b/apps/api-gateway/src/dtos/migrate-schema.dto.ts
@@ -18,7 +18,7 @@ export class MigrateW3CSchemaDto {
 
     @ApiProperty({
       description: 'The target schema type (only Ethereum supported)',
-      enum: JSONSchemaType,
+      enum: [JSONSchemaType.ETHEREUM_W3C],
       example: JSONSchemaType.ETHEREUM_W3C 
     })
     @Equals(JSONSchemaType.ETHEREUM_W3C, {

--- a/apps/api-gateway/src/schema/schema.controller.ts
+++ b/apps/api-gateway/src/schema/schema.controller.ts
@@ -21,6 +21,7 @@ import { GenericSchemaDTO } from '../dtos/create-schema.dto';
 import { CustomExceptionFilter } from 'apps/api-gateway/common/exception-handler';
 import { CredDefSortFields, SortFields } from '@credebl/enum/enum';
 import { TrimStringParamPipe } from '@credebl/common/cast.helper';
+import { MigrateW3CSchemaDto } from '../dtos/migrate-schema.dto';
 
 @UseFilters(CustomExceptionFilter)
 @Controller('orgs')
@@ -149,6 +150,25 @@ export class SchemaController {
     const finalResponse: IResponse = {
       statusCode: HttpStatus.CREATED,
       message: ResponseMessages.schema.success.create,
+      data: schemaResponse
+    };
+    return res.status(HttpStatus.CREATED).json(finalResponse);
+  }
+
+  @Post('/:orgId/migrate-schema')
+  @ApiOperation({
+    summary: 'Migrate anchor of schemas to another ledger.',
+    description: 'Enables the migration of schemas across different ledgers'
+  }
+  )
+  @Roles(OrgRoles.OWNER, OrgRoles.ADMIN)
+  @UseGuards(AuthGuard('jwt'), OrgRolesGuard)
+  @ApiResponse({ status: HttpStatus.CREATED, description: 'Success', type: ApiResponseDto })
+  async migrateSchema(@Res() res: Response, @Body() migrateSchemaDetails: MigrateW3CSchemaDto, @Param('orgId', new ParseUUIDPipe({exceptionFactory: (): Error => { throw new BadRequestException(ResponseMessages.organisation.error.invalidOrgId); }})) orgId: string, @User() user: IUserRequestInterface): Promise<Response> {
+  const schemaResponse = await this.appService.migrateSchema(migrateSchemaDetails, user, orgId);
+    const finalResponse: IResponse = {
+      statusCode: HttpStatus.CREATED,
+      message: ResponseMessages.schema.success.migrate,
       data: schemaResponse
     };
     return res.status(HttpStatus.CREATED).json(finalResponse);

--- a/apps/api-gateway/src/schema/schema.controller.ts
+++ b/apps/api-gateway/src/schema/schema.controller.ts
@@ -158,7 +158,7 @@ export class SchemaController {
   @Post('/:orgId/migrate-schema')
   @ApiOperation({
     summary: 'Migrate anchor of schemas to another ledger.',
-    description: 'Enables the migration of schemas across different ledgers'
+    description: 'Enables the migration of schemas from current ledger to Ethereum network.'
   }
   )
   @Roles(OrgRoles.OWNER, OrgRoles.ADMIN)

--- a/apps/api-gateway/src/schema/schema.service.ts
+++ b/apps/api-gateway/src/schema/schema.service.ts
@@ -6,6 +6,7 @@ import { ISchemaSearchPayload } from '../interfaces/ISchemaSearch.interface';
 import { ISchemaInfo, IUserRequestInterface } from './interfaces';
 import { ICredDefWithPagination, ISchemaData, ISchemasWithPagination } from '@credebl/common/interfaces/schema.interface';
 import { GetCredentialDefinitionBySchemaIdDto } from './dtos/get-all-schema.dto';
+import { MigrateW3CSchemaDto } from '../dtos/migrate-schema.dto';
 
 @Injectable()
 export class SchemaService extends BaseService {
@@ -17,6 +18,11 @@ export class SchemaService extends BaseService {
   createSchema(schemaDetails: GenericSchemaDTO, user: IUserRequestInterface, orgId: string): Promise<ISchemaData> {
     const payload = { schemaDetails, user, orgId };
     return this.sendNatsMessage(this.schemaServiceProxy, 'create-schema', payload);
+  }
+
+  migrateSchema(migrateSchemaDetails: MigrateW3CSchemaDto, user: IUserRequestInterface, orgId: string): Promise<ISchemaData> {
+    const payload = { migrateSchemaDetails, user, orgId };
+    return this.sendNatsMessage(this.schemaServiceProxy, 'migrate-w3c-schema', payload);
   }
 
   

--- a/apps/ledger/src/schema/interfaces/schema-payload.interface.ts
+++ b/apps/ledger/src/schema/interfaces/schema-payload.interface.ts
@@ -20,6 +20,12 @@ export interface ISchema {
     type?: string;
 }
 
+export interface IUpdateSchema {
+    id: string;
+    changedBy: string;
+    ledgerId?: string;
+}
+
 export interface IAttributeValue {
     isRequired: boolean;    
     attributeName: string;
@@ -98,6 +104,12 @@ export interface W3CCreateSchema {
     orgId: string,
     schemaRequestPayload: object
 }  
+
+export interface W3CMigrateSchema {
+    url: string,
+    orgId: string,
+    schemaRequestPayload: object
+} 
 
 export interface IdAttribute extends W3CSchemaAttributes {
     format: string;

--- a/apps/ledger/src/schema/interfaces/schema.interface.ts
+++ b/apps/ledger/src/schema/interfaces/schema.interface.ts
@@ -109,7 +109,7 @@ export interface IschemaPayload {
   orgId: string
 }
 
-export interface IMigrateW3cSchemaPayload {
+export interface IMigrateW3CSchemaPayload {
   migrateSchemaDetails: IMigrateW3CSchema,
   user: IUserRequestInterface,
   orgId: string

--- a/apps/ledger/src/schema/interfaces/schema.interface.ts
+++ b/apps/ledger/src/schema/interfaces/schema.interface.ts
@@ -93,6 +93,11 @@ export interface ICreateW3CSchema {
   description: string;
   schemaType: JSONSchemaType;
 }
+
+export interface IMigrateW3CSchema {
+  schemaId: string;
+  targetSchemaType: JSONSchemaType.ETHEREUM_W3C;
+}
 export interface IGenericSchema {
   type: SchemaTypeEnum;
   schemaPayload: ICreateSchema | ICreateW3CSchema;
@@ -100,6 +105,12 @@ export interface IGenericSchema {
 
 export interface IschemaPayload {
   schemaDetails: IGenericSchema,
+  user: IUserRequestInterface,
+  orgId: string
+}
+
+export interface IMigrateW3cSchemaPayload {
+  migrateSchemaDetails: IMigrateW3CSchema,
   user: IUserRequestInterface,
   orgId: string
 }

--- a/apps/ledger/src/schema/repositories/schema.repository.ts
+++ b/apps/ledger/src/schema/repositories/schema.repository.ts
@@ -2,7 +2,7 @@
 import { ConflictException, Injectable, InternalServerErrorException, Logger } from '@nestjs/common';
 import { PrismaService } from '@credebl/prisma-service';
 import { ledgers, org_agents, org_agents_type, organisation, schema } from '@prisma/client';
-import { ISchema, ISchemaExist, ISchemaSearchCriteria } from '../interfaces/schema-payload.interface';
+import { ISchema, ISchemaExist, ISchemaSearchCriteria, IUpdateSchema } from '../interfaces/schema-payload.interface';
 import { ResponseMessages } from '@credebl/common/response-messages';
 import { AgentDetails, ISchemasWithCount } from '../interfaces/schema.interface';
 import { SchemaType, SortValue } from '@credebl/enum/enum';
@@ -43,6 +43,24 @@ export class SchemaRepository {
       }
     } catch (error) {
       this.logger.error(`Error in saving schema repository: ${error.message} `);
+      throw error;
+    }
+  }
+
+  async updateSchema(updateSchema: IUpdateSchema): Promise<schema> {
+    try {
+      const updateResult = await this.prisma.schema.update({
+        where: {
+          id: updateSchema.id
+        },
+        data: {
+          ledgerId: updateSchema.ledgerId,
+          lastChangedBy: updateSchema.changedBy
+        }
+      });
+      return updateResult;
+    } catch (error) {
+      this.logger.error(`Error in updating schema repository: ${error.message} `);
       throw error;
     }
   }
@@ -333,6 +351,20 @@ export class SchemaRepository {
       });
     } catch (error) {
       this.logger.error(`Error in getting get schema by schema ledger id: ${error}`);
+      throw error;
+    }
+  }
+
+  async getSchemaByOrgSchemaUrl(schemaUrl: string, orgId: string): Promise<schema> {
+    try {
+      return this.prisma.schema.findFirst({
+        where: {
+          orgId,
+          schemaLedgerId: schemaUrl
+        }
+      });
+    } catch (error) {
+      this.logger.error(`Error in getting get schema by org id and ledger id: ${error}`);
       throw error;
     }
   }

--- a/apps/ledger/src/schema/schema.controller.ts
+++ b/apps/ledger/src/schema/schema.controller.ts
@@ -14,7 +14,7 @@ import {
   ISchemaDetails,
   ISchemasWithPagination
 } from '@credebl/common/interfaces/schema.interface';
-import { IschemaPayload } from './interfaces/schema.interface';
+import { IMigrateW3cSchemaPayload, IschemaPayload } from './interfaces/schema.interface';
 
 @Controller('schema')
 export class SchemaController {
@@ -24,6 +24,12 @@ export class SchemaController {
   async createSchema(payload: IschemaPayload): Promise<ISchemaData> {
     const { schemaDetails, user, orgId } = payload;
     return this.schemaService.createSchema(schemaDetails, user, orgId);
+  }
+
+  @MessagePattern({ cmd: 'migrate-w3c-schema' })
+  async migrateW3cSchema(payload: IMigrateW3cSchemaPayload): Promise<ISchemaData> {
+    const { migrateSchemaDetails, user, orgId } = payload;
+    return this.schemaService.migrateW3CSchema(migrateSchemaDetails, user, orgId);
   }
 
   @MessagePattern({ cmd: 'get-schemas-details' })

--- a/apps/ledger/src/schema/schema.service.ts
+++ b/apps/ledger/src/schema/schema.service.ts
@@ -10,9 +10,9 @@ import { ClientProxy, RpcException } from '@nestjs/microservices';
 import { BaseService } from 'libs/service/base.service';
 import { SchemaRepository } from './repositories/schema.repository';
 import { schema } from '@prisma/client';
-import { ISchema, ISchemaCredDeffSearchInterface, ISchemaExist, ISchemaSearchCriteria, W3CCreateSchema } from './interfaces/schema-payload.interface';
+import { ISchema, ISchemaCredDeffSearchInterface, ISchemaExist, ISchemaSearchCriteria, IUpdateSchema, W3CCreateSchema, W3CMigrateSchema } from './interfaces/schema-payload.interface';
 import { ResponseMessages } from '@credebl/common/response-messages';
-import { ICreateSchema, ICreateW3CSchema, IGenericSchema, IUserRequestInterface } from './interfaces/schema.interface';
+import { ICreateSchema, ICreateW3CSchema, IGenericSchema, IMigrateW3CSchema, IUserRequestInterface } from './interfaces/schema.interface';
 import { CreateSchemaAgentRedirection, GetSchemaAgentRedirection } from './schema.interface';
 import { map } from 'rxjs/operators';
 import { JSONSchemaType, LedgerLessConstant, LedgerLessMethods, OrgAgentType, SchemaType, SchemaTypeEnum } from '@credebl/enum/enum';
@@ -345,6 +345,76 @@ export class SchemaService extends BaseService {
     }
   }
 
+  async migrateW3CSchema(schemaPayload: IMigrateW3CSchema, user: IUserRequestInterface, orgId:string): Promise<ISchemaData> {
+    try {
+      const { schemaId, targetSchemaType } = schemaPayload;
+      const agentDetails = await this.schemaRepository.getAgentDetailsByOrgId(orgId);
+      if (!agentDetails) {
+        throw new NotFoundException(ResponseMessages.schema.error.agentDetailsNotFound, {
+          cause: new Error(),
+          description: ResponseMessages.errorMessages.notFound
+        });
+      }
+      const schemaUrl =  `${process.env.SCHEMA_FILE_SERVER_URL}${schemaId}`;
+      const schema = await this.schemaRepository.getSchemaByOrgSchemaUrl(schemaUrl, orgId);
+      if (!schema) {
+        throw new NotFoundException(ResponseMessages.schema.error.notFound, {
+          cause: new Error(),
+          description: ResponseMessages.errorMessages.notFound
+        });
+      }
+
+      const { agentEndPoint } = agentDetails;
+
+      const ledgerAndNetworkDetails = await checkDidLedgerAndNetwork(targetSchemaType, agentDetails.orgDid);
+      if (!ledgerAndNetworkDetails) {
+        throw new BadRequestException(ResponseMessages.schema.error.orgDidAndSchemaType, {
+          cause: new Error(),
+          description: ResponseMessages.errorMessages.badRequest
+        });
+      }
+     
+      const getAgentDetails = await this.schemaRepository.getAgentType(orgId);
+      const orgAgentType = await this.schemaRepository.getOrgAgentType(getAgentDetails.org_agents[0].orgAgentTypeId);
+      let url;
+      if (OrgAgentType.DEDICATED === orgAgentType) {
+        url = `${agentEndPoint}${CommonConstants.DEDICATED_MIGRATE_ETHEREUM_W3C_SCHEMA}`;
+      } else if (OrgAgentType.SHARED === orgAgentType) {
+        const { tenantId } = await this.schemaRepository.getAgentDetailsByOrgId(orgId);
+          url = `${agentEndPoint}${CommonConstants.SHARED_MIGRATE_ETHEREUM_W3C_SCHEMA}${tenantId}`;
+      }
+      const agentSchemaPayload = {
+        did: agentDetails.orgDid,
+        schemaId
+      };
+      const W3cSchemaPayload : W3CMigrateSchema = {
+        url,
+        orgId,
+        schemaRequestPayload: agentSchemaPayload
+      };
+
+      await this._migrateW3CSchema(W3cSchemaPayload);
+     
+      const updateSchema = {
+        id: schema.id,
+        did: agentDetails.orgDid
+      };
+      const updateW3CSchema = await this.updateW3CSchemas(updateSchema, user);
+
+     if (!updateW3CSchema) {
+      throw new BadRequestException(ResponseMessages.schema.error.updateW3CSchema, {
+        cause: new Error(),
+        description: ResponseMessages.errorMessages.serverError
+      });
+     }
+      
+      return updateW3CSchema;
+    } catch (error) {
+      this.logger.error(`[migrateW3CSchema] - outer Error: ${JSON.stringify(error)}`);
+      throw error;
+    }
+  }
+
   private async w3cSchemaBuilder(attributes, schemaName: string, description: string): Promise<object> {
     const schemaAttributeJson = attributes.map((attribute, index) => ({
       [attribute.attributeName]: {
@@ -574,6 +644,27 @@ export class SchemaService extends BaseService {
     );
     return saveResponse;
    }
+
+   private async updateW3CSchemas(updateSchema, user): Promise <schema> {
+      const ledgerNameSpace = await networkNamespace(updateSchema?.did); 
+      const ledgerDetails = await this.schemaRepository.getLedgerByNamespace(ledgerNameSpace);
+
+      if (!ledgerDetails) {
+        throw new NotFoundException(ResponseMessages.schema.error.networkNotFound, {
+          cause: new Error(),
+          description: ResponseMessages.errorMessages.notFound
+        });
+      }
+      const updateSchemaDetails: IUpdateSchema = {
+        id: updateSchema.id,
+        changedBy: user.id,
+        ledgerId: ledgerDetails.id
+      };
+      const updateResponse = await this.schemaRepository.updateSchema(
+        updateSchemaDetails
+      );
+      return updateResponse;
+   }
   
   async _createSchema(payload: CreateSchemaAgentRedirection): Promise<{
     response: string;
@@ -617,6 +708,32 @@ export class SchemaService extends BaseService {
         ).toPromise()
         .catch(error => {
           this.logger.error(`Error in creating W3C schema : ${JSON.stringify(error)}`);
+          throw new HttpException(
+            {
+              status: error.error.code,  
+              error: error.message,
+              message: error.error.message.error.message
+            }, error.error);
+        });
+      return W3CSchemaResponse;  
+  }
+
+  async _migrateW3CSchema(payload: W3CMigrateSchema): Promise<{
+    response: string;
+  }> {
+      const natsPattern = {
+        cmd: 'agent-migrate-w3c-schema'
+      };
+      const W3CSchemaResponse = await this.schemaServiceProxy
+        .send(natsPattern, payload)
+        .pipe(
+          map((response) => (
+            {
+              response
+            }))
+        ).toPromise()
+        .catch(error => {
+          this.logger.error(`Error in migrating W3C schema : ${JSON.stringify(error)}`);
           throw new HttpException(
             {
               status: error.error.code,  

--- a/libs/common/src/common.constant.ts
+++ b/libs/common/src/common.constant.ts
@@ -91,8 +91,10 @@ export enum CommonConstants {
   // POLYGON BASED W3C SCHEMAS
   DEDICATED_CREATE_POLYGON_W3C_SCHEMA = '/polygon/create-schema',
   DEDICATED_CREATE_ETHEREUM_W3C_SCHEMA = '/ethereum/create-schema',
+  DEDICATED_MIGRATE_ETHEREUM_W3C_SCHEMA = '/ethereum/migrate-schema',
   SHARED_CREATE_POLYGON_W3C_SCHEMA = '/multi-tenancy/polygon-wc3/schema/',
   SHARED_CREATE_ETHEREUM_W3C_SCHEMA = '/multi-tenancy/ethereum-wc3/schema/',
+  SHARED_MIGRATE_ETHEREUM_W3C_SCHEMA = '/multi-tenancy/ethereum-wc3/migrate-schema/',
 
   // SHARED AGENT
   URL_SHAGENT_CREATE_TENANT = '/multi-tenancy/create-tenant',

--- a/libs/common/src/common.utils.ts
+++ b/libs/common/src/common.utils.ts
@@ -1,6 +1,7 @@
 import { NotFoundException } from '@nestjs/common';
 import * as dotenv from 'dotenv';
 import { ResponseMessages } from './response-messages';
+import { CommonConstants } from './common.constant';
 dotenv.config();
 /* eslint-disable camelcase */
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/explicit-function-return-type
@@ -66,6 +67,6 @@ export const networkNamespace = (did: string):string => {
   if (containsTestnet) {
     return `${segments[1]}:${segments[2]}`;
   } else {
-    return segments[1];
+    return `${segments[1]}:${CommonConstants.MAINNET}`;
   }
 };

--- a/libs/common/src/response-messages/index.ts
+++ b/libs/common/src/response-messages/index.ts
@@ -156,7 +156,8 @@ export const ResponseMessages = {
   schema: {
     success: {
       fetch: 'Schema retrieved successfully.',
-      create: 'Schema created successfully.'
+      create: 'Schema created successfully.',
+      migrate: 'Schema migrated successfully.'
     },
     error: {
       invalidSchemaId: 'Invalid schema Id provided.',
@@ -181,6 +182,7 @@ export const ResponseMessages = {
       schemaUploading: 'Error while uploading schema JSON',
       W3CSchemaNotFOund: 'Error while resolving W3C schema',
       storeW3CSchema: 'Error while storing W3C schema',
+      updateW3CSchema: 'Error while updating W3C schema',
       networkNotFound: 'Error while fetching network',
       orgDidAndSchemaType: 'Organization DID and schema type does not match'
     }


### PR DESCRIPTION
**Summary**

This PR adds support for migrating an existing W3C schema to an Ethereum-anchored schema type.

A new endpoint is introduced:

`POST /:orgId/migrate-schema`

This allows an organization to migrate a stored W3C schema to the supported target type:
ETHEREUM_W3C.

**What’s Included**

- New MigrateW3CSchemaDto with validation (only ETHEREUM_W3C is allowed)
- Controller and service updates in API Gateway
- Agent service support for migrate-w3c-schema
- Ledger service handling for Ethereum schema migration
- Required NATS message patterns

**Why**

This enables anchoring W3C schemas on the Ethereum ledger, aligning the platform with the move toward Ethereum-based identity infrastructure.