### PR TITLE
[General] fix: return first non-null invitation DID for reuse connection (#29)

### DIFF
--- a/apps/connection/src/connection.repository.ts
+++ b/apps/connection/src/connection.repository.ts
@@ -379,11 +379,20 @@ export class ConnectionRepository {
   }
 
    // eslint-disable-next-line camelcase
-   async getInvitationDidByOrgId(orgId: string): Promise<agent_invitations[]> {
+   async getInvitationDidByOrgId(orgId: string): Promise<agent_invitations> {
     try {
-      return this.prisma.agent_invitations.findMany({
+      return this.prisma.agent_invitations.findFirst({
         where: {
-          orgId
+          AND: [
+            {
+              orgId
+            },
+            {
+              invitationDid: {
+                not: null
+              }
+            }
+          ]
         },
         orderBy: {
           createDateTime: 'asc'

--- a/apps/connection/src/connection.service.ts
+++ b/apps/connection/src/connection.service.ts
@@ -500,13 +500,9 @@ export class ConnectionService {
 
       let legacyinvitationDid;
       if (IsReuseConnection) {
-        const data: agent_invitations[] = await this.connectionRepository.getInvitationDidByOrgId(orgId);
-        if (data && 0 < data.length) {
-          const [firstElement] = data;
-          legacyinvitationDid = firstElement?.invitationDid ?? undefined;
-
-          this.logger.log('legacyinvitationDid:', legacyinvitationDid);
-        }
+        const invitation: agent_invitations = await this.connectionRepository.getInvitationDidByOrgId(orgId);
+        legacyinvitationDid = invitation?.invitationDid ?? undefined;
+        this.logger.log('legacyinvitationDid:', legacyinvitationDid);
       }
       const connectionInvitationDid = invitationDid ? invitationDid : legacyinvitationDid;
 

--- a/apps/issuance/src/issuance.repository.ts
+++ b/apps/issuance/src/issuance.repository.ts
@@ -93,11 +93,20 @@ export class IssuanceRepository {
     }
   }
 
-  async getInvitationDidByOrgId(orgId: string): Promise<agent_invitations[]> {
+  async getInvitationDidByOrgId(orgId: string): Promise<agent_invitations> {
     try {
-      return this.prisma.agent_invitations.findMany({
+      return this.prisma.agent_invitations.findFirst({
         where: {
-          orgId
+          AND: [
+            {
+              orgId
+            },
+            {
+              invitationDid: {
+                not: null
+              }
+            }
+          ]
         },
         orderBy: {
           createDateTime: 'asc'

--- a/apps/issuance/src/issuance.service.ts
+++ b/apps/issuance/src/issuance.service.ts
@@ -377,11 +377,8 @@ export class IssuanceService {
       const agentDetails = await this.issuanceRepository.getAgentEndPoint(orgId);
       let invitationDid: string | undefined;
       if (true === reuseConnection) {
-        const data: agent_invitations[] = await this.issuanceRepository.getInvitationDidByOrgId(orgId);
-        if (data && 0 < data.length) {
-          const [firstElement] = data;
-          invitationDid = firstElement?.invitationDid ?? undefined;
-        }
+        const invitation: agent_invitations = await this.issuanceRepository.getInvitationDidByOrgId(orgId);
+        invitationDid = invitation?.invitationDid ?? undefined;
       }
       const { agentEndPoint, organisation } = agentDetails;
 
@@ -984,11 +981,8 @@ export class IssuanceService {
       let invitationDid: string | undefined;
       if (true === isReuseConnection) {
         this.logger.debug('This is a reuse connection, fetching invitation did');
-        const data: agent_invitations[] = await this.issuanceRepository.getInvitationDidByOrgId(orgId);
-        if (data && 0 < data.length) {
-          const [firstElement] = data;
-          invitationDid = firstElement?.invitationDid ?? undefined;
-        }
+        const invitation: agent_invitations = await this.issuanceRepository.getInvitationDidByOrgId(orgId);
+        invitationDid = invitation?.invitationDid ?? undefined;
       }
 
       let outOfBandIssuancePayload;

--- a/apps/verification/src/repositories/verification.repository.ts
+++ b/apps/verification/src/repositories/verification.repository.ts
@@ -292,11 +292,20 @@ export class VerificationRepository {
   }
 
   // eslint-disable-next-line camelcase
-  async getInvitationDidByOrgId(orgId: string): Promise<agent_invitations[]> {
+  async getInvitationDidByOrgId(orgId: string): Promise<agent_invitations> {
     try {
-      return this.prisma.agent_invitations.findMany({
+      return this.prisma.agent_invitations.findFirst({
         where: {
-          orgId
+          AND: [
+            {
+              orgId
+            },
+            {
+              invitationDid: {
+                not: null
+              }
+            }
+          ]
         },
         orderBy: {
           createDateTime: 'asc' // or 'desc' for descending order

--- a/apps/verification/src/verification.service.ts
+++ b/apps/verification/src/verification.service.ts
@@ -483,11 +483,8 @@ export class VerificationService {
       const { isShortenUrl, emailId, type, reuseConnection, ...updateOutOfBandRequestProof } = outOfBandRequestProof;
       let invitationDid: string | undefined;
       if (true === reuseConnection) {
-        const data: agent_invitations[] = await this.verificationRepository.getInvitationDidByOrgId(user.orgId);
-        if (data && 0 < data.length) {
-          const [firstElement] = data;
-          invitationDid = firstElement?.invitationDid ?? undefined;
-        }
+        const invitation: agent_invitations = await this.verificationRepository.getInvitationDidByOrgId(user.orgId);
+        invitationDid = invitation?.invitationDid ?? undefined;
       }
       outOfBandRequestProof.autoAcceptProof = outOfBandRequestProof.autoAcceptProof || AutoAccept.Always;
 


### PR DESCRIPTION
## [General] Correct invitation-DID lookup for reuse connection

Re-applies the Bhutan-NDI custom fix from **pipeline-implementation #29** ("fix/invitation-did-query") onto the v2.2.0 baseline — **General (foundation)** workstream, Phase A.

### Problem
`getInvitationDidByOrgId` used `findMany` ordered by `createDateTime asc` and callers took the first row. If that earliest `agent_invitations` row had a **null `invitationDid`**, reuse-connection resolved to `undefined` and the reuse path silently failed.

### Fix
- Repositories (`connection`, `issuance`, `verification`): `findMany` → `findFirst` with `where: { AND: [{ orgId }, { invitationDid: { not: null } }] }`; return type `agent_invitations[]` → `agent_invitations`. Returns the earliest invitation that actually has a DID.
- Call sites (connection, verification, issuance ×2): read a single record — `invitation?.invitationDid ?? undefined` — dropping the array/length/destructure dance.

### Deviations from source
- Re-applied **by content** (unrelated histories). Conforms to `develop` structure; `AND` block indentation normalized to baseline style (behavior identical).
- Minimal-diff commit (`--no-verify`) per the migration's formatting decision; ESLint run manually on changed files.

### Verification
- ESLint: no new findings (the 2 pre-existing `implicit-arrow-linebreak` errors in `issuance.service.ts` exist identically on `develop`).
- `tsc --noEmit`: 109 errors = `develop` baseline; none in changed files.

Base: `develop`
