### PR TITLE
[General] feat: forward parentThreadId through credential-offer issuance (#56)

### DIFF
--- a/apps/api-gateway/src/issuance/issuance.service.ts
+++ b/apps/api-gateway/src/issuance/issuance.service.ts
@@ -50,6 +50,7 @@ export class IssuanceService extends BaseService {
       autoAcceptCredential: issueCredentialDto.autoAcceptCredential,
       credentialType: issueCredentialDto.credentialType,
       isValidateSchema: issueCredentialDto.isValidateSchema,
+      parentThreadId: issueCredentialDto.parentThreadId,
       user
     };
 

--- a/apps/issuance/interfaces/issuance.interfaces.ts
+++ b/apps/issuance/interfaces/issuance.interfaces.ts
@@ -43,6 +43,7 @@ interface IIndy {
 
 export interface IIssueData {
   protocolVersion?: string;
+  parentThreadId?: string;
   connectionId: string;
   credentialFormats: {
     indy: IIndy;

--- a/apps/issuance/src/issuance.service.ts
+++ b/apps/issuance/src/issuance.service.ts
@@ -234,6 +234,7 @@ export class IssuanceService {
           issueData = {
             protocolVersion: payload.protocolVersion || 'v2',
             connectionId,
+            parentThreadId: payload.parentThreadId || undefined,
             credentialFormats: {
               jsonld: {
                 credential,


### PR DESCRIPTION
## [General] Forward parentThreadId through credential-offer issuance

Re-applies **pipeline-implementation #56** ("feat: parentThreadId for credential issuance") — **General (foundation)** workstream, Phase A.

### Context
`IssueCredentialDto.parentThreadId` is already present on the v2.2.0 baseline (upstream), but it was **not forwarded** through the single credential-offer path — so a caller-supplied `parentThreadId` was silently dropped.

### Changes (wiring only)
- `apps/api-gateway/src/issuance/issuance.service.ts` — include `parentThreadId` in the `send-credential-create-offer` NATS payload.
- `apps/issuance/interfaces/issuance.interfaces.ts` — declare `parentThreadId?` on `IIssueData`.
- `apps/issuance/src/issuance.service.ts` — pass `parentThreadId: payload.parentThreadId || undefined` in the JSON-LD `issueData` construction (matching the pattern already used by the OOB/bulk paths in this file).

### Deviations from source
- Re-applied **by content**; only the pieces missing on `develop` were added (the DTO field and the OOB/bulk-path wiring were already present).
- Used `|| undefined` to match `develop`'s existing convention in this file (source used `?? undefined`).
- Minimal-diff commit (`--no-verify`) per the migration formatting decision; ESLint run manually.

### Verification
- ESLint: no new findings (the 2 `implicit-arrow-linebreak` errors in `issuance.service.ts` are pre-existing on `develop`).
- `tsc --noEmit`: 109 errors = `develop` baseline; none in changed files.

Base: `develop`
