### PR TITLE
[General] feat(storage): selectable AWS/Azure provider via STORAGE_TYPE

### DIFF
--- a/.env.demo
+++ b/.env.demo
@@ -111,8 +111,12 @@ PLATFORM_ID=1
 POOL_DATABASE_URL="postgresql://postgres:postgres@your-ip:5432/credebl"
 DATABASE_URL="postgresql://postgres:postgres@your-ip:5432/credebl"
 
+# Storage provider selection: 'aws' (S3) or 'azure' (Blob). Defaults to 'aws' when unset.
+# Set the corresponding AWS_* or AZURE_* values below for the chosen provider.
+STORAGE_TYPE=aws
+
 # Used for Bulk issuance of credential (Optional- Can be skipped if Bulk issuance is not used)
-# Provide aws bucket access credentails 
+# Provide aws bucket access credentails
 AWS_ACCESS_KEY=
 AWS_SECRET_KEY=
 AWS_REGION=

--- a/apps/api-gateway/src/issuance/issuance.controller.ts
+++ b/apps/api-gateway/src/issuance/issuance.controller.ts
@@ -21,7 +21,8 @@ import {
   NotFoundException,
   ParseUUIDPipe,
   Delete,
-  ValidationPipe
+  ValidationPipe,
+  Inject
 } from '@nestjs/common';
 import {
   ApiTags,
@@ -69,7 +70,7 @@ import {
   IssueCredentialType,
   UploadedFileDetails
 } from './interfaces';
-import { AzureStorageService } from '@credebl/azure-storage';
+import { STORAGE_SERVICE, StorageService } from '@credebl/storage';
 import { FileInterceptor } from '@nestjs/platform-express';
 import { v4 as uuidv4 } from 'uuid';
 import { RpcException } from '@nestjs/microservices';
@@ -93,7 +94,7 @@ import { MarketplaceService } from '../marketplace/marketplace.service';
 export class IssuanceController {
   constructor(
     private readonly issueCredentialService: IssuanceService,
-    private readonly azureStorageService: AzureStorageService,
+    @Inject(STORAGE_SERVICE) private readonly storageService: StorageService,
     private readonly marketplaceService: MarketplaceService
   ) {}
   private readonly logger = new Logger('IssuanceController');
@@ -382,7 +383,7 @@ export class IssuanceController {
     if (file) {
       const fileKey: string = uuidv4();
       try {
-        await this.azureStorageService.uploadCsvFile(fileKey, file?.buffer);
+        await this.storageService.uploadCsvFile(fileKey, file?.buffer);
       } catch (error) {
         throw new RpcException(error.response ? error.response : error);
       }
@@ -536,7 +537,7 @@ export class IssuanceController {
     if (file && clientDetails?.isSelectiveIssuance) {
       const fileKey: string = uuidv4();
       try {
-        await this.azureStorageService.uploadCsvFile(fileKey, file.buffer);
+        await this.storageService.uploadCsvFile(fileKey, file.buffer);
       } catch (error) {
         throw new RpcException(error.response ? error.response : error);
       }

--- a/apps/api-gateway/src/issuance/issuance.module.ts
+++ b/apps/api-gateway/src/issuance/issuance.module.ts
@@ -5,13 +5,14 @@ import { IssuanceService } from './issuance.service';
 import { CommonService } from '@credebl/common';
 import { HttpModule } from '@nestjs/axios';
 import { getNatsOptions } from '@credebl/common/nats.config';
-import { AzureStorageService } from '@credebl/azure-storage';
+import { StorageModule } from '@credebl/storage';
 import { CommonConstants } from '@credebl/common/common.constant';
 import { NATSClient } from '@credebl/common/NATSClient';
 
 @Module({
   imports: [
     HttpModule,
+    StorageModule,
     ClientsModule.register([
       {
         name: 'NATS_CLIENT',
@@ -25,6 +26,6 @@ import { NATSClient } from '@credebl/common/NATSClient';
     ])
   ],
   controllers: [IssuanceController],
-  providers: [IssuanceService, CommonService, AzureStorageService, NATSClient]
+  providers: [IssuanceService, CommonService, NATSClient]
 })
 export class IssuanceModule {}

--- a/apps/api-gateway/src/organization/organization.module.ts
+++ b/apps/api-gateway/src/organization/organization.module.ts
@@ -7,7 +7,6 @@ import { Module } from '@nestjs/common';
 import { OrganizationController } from './organization.controller';
 import { OrganizationService } from './organization.service';
 import { getNatsOptions } from '@credebl/common/nats.config';
-import { AzureStorageService } from '@credebl/azure-storage';
 import { CommonConstants } from '@credebl/common/common.constant';
 import { NATSClient } from '@credebl/common/NATSClient';
 @Module({
@@ -28,6 +27,6 @@ import { NATSClient } from '@credebl/common/NATSClient';
     ])
   ],
   controllers: [OrganizationController],
-  providers: [OrganizationService, CommonService, AzureStorageService, NATSClient]
+  providers: [OrganizationService, CommonService, NATSClient]
 })
 export class OrganizationModule {}

--- a/apps/api-gateway/src/user/user.controller.ts
+++ b/apps/api-gateway/src/user/user.controller.ts
@@ -47,7 +47,6 @@ import { UpdatePlatformSettingsDto } from './dto/update-platform-settings.dto';
 import { Roles } from '../authz/decorators/roles.decorator';
 import { OrgRolesGuard } from '../authz/guards/org-roles.guard';
 import { OrgRoles } from 'libs/org-roles/enums';
-import { AzureStorageService } from '@credebl/azure-storage';
 import { PaginationDto } from '@credebl/common/dtos/pagination.dto';
 import { UserAccessGuard } from '../authz/guards/user-access-guard';
 import { TrimStringParamPipe } from '@credebl/common/cast.helper';
@@ -60,8 +59,7 @@ import { TrimStringParamPipe } from '@credebl/common/cast.helper';
 export class UserController {
   constructor(
     private readonly userService: UserService,
-    private readonly commonService: CommonService,
-    private readonly azureStorageService: AzureStorageService
+    private readonly commonService: CommonService
   ) {}
 
   /**

--- a/apps/api-gateway/src/user/user.module.ts
+++ b/apps/api-gateway/src/user/user.module.ts
@@ -6,7 +6,6 @@ import { Module } from '@nestjs/common';
 import { UserController } from './user.controller';
 import { UserService } from './user.service';
 import { getNatsOptions } from '@credebl/common/nats.config';
-import { AzureStorageService } from '@credebl/azure-storage';
 import { CommonConstants } from '@credebl/common/common.constant';
 import { NATSClient } from '@credebl/common/NATSClient';
 
@@ -27,6 +26,6 @@ import { NATSClient } from '@credebl/common/NATSClient';
     ])
   ],
   controllers: [UserController],
-  providers: [UserService, CommonService, AzureStorageService, NATSClient]
+  providers: [UserService, CommonService, NATSClient]
 })
 export class UserModule {}

--- a/apps/api-gateway/src/webhook/webhook.module.ts
+++ b/apps/api-gateway/src/webhook/webhook.module.ts
@@ -5,7 +5,6 @@ import { WebhookService } from './webhook.service';
 import { CommonService } from '@credebl/common';
 import { HttpModule } from '@nestjs/axios';
 import { getNatsOptions } from '@credebl/common/nats.config';
-import { AzureStorageService } from '@credebl/azure-storage';
 import { CommonConstants } from '@credebl/common/common.constant';
 import { NATSClient } from '@credebl/common/NATSClient';
 
@@ -25,6 +24,6 @@ import { NATSClient } from '@credebl/common/NATSClient';
     ])
   ],
   controllers: [WebhookController],
-  providers: [WebhookService, CommonService, AzureStorageService, NATSClient]
+  providers: [WebhookService, CommonService, NATSClient]
 })
 export class WebhookModule {}

--- a/apps/api-gateway/src/x509/x509.module.ts
+++ b/apps/api-gateway/src/x509/x509.module.ts
@@ -5,7 +5,6 @@ import { Module } from '@nestjs/common';
 import { X509Controller } from './x509.controller';
 import { X509Service } from './x509.service';
 import { getNatsOptions } from '@credebl/common/nats.config';
-import { AzureStorageService } from '@credebl/azure-storage';
 import { CommonConstants } from '@credebl/common/common.constant';
 import { NATSClient } from '@credebl/common/NATSClient';
 @Module({
@@ -25,6 +24,6 @@ import { NATSClient } from '@credebl/common/NATSClient';
     ])
   ],
   controllers: [X509Controller],
-  providers: [X509Service, AzureStorageService, NATSClient]
+  providers: [X509Service, NATSClient]
 })
 export class X509Module {}

--- a/apps/issuance/src/issuance.module.ts
+++ b/apps/issuance/src/issuance.module.ts
@@ -12,7 +12,7 @@ import { EmailDto } from '@credebl/common/dtos/email.dto';
 import { BullModule } from '@nestjs/bull';
 import { CacheModule } from '@nestjs/cache-manager';
 import { BulkIssuanceProcessor } from './issuance.processor';
-import { AzureStorageService } from '@credebl/azure-storage';
+import { StorageModule } from '@credebl/storage';
 import { UserActivityRepository } from 'libs/user-activity/repositories';
 import { CommonConstants, MICRO_SERVICE_NAME } from '@credebl/common/common.constant';
 import { LoggerModule } from '@credebl/logger/logger.module';
@@ -36,6 +36,7 @@ import { NATSClient } from '@credebl/common/NATSClient';
       }
     ]),
     CommonModule,
+    StorageModule,
     GlobalConfigModule,
     LoggerModule,
     PlatformConfig,
@@ -61,7 +62,6 @@ import { NATSClient } from '@credebl/common/NATSClient';
     OutOfBandIssuance,
     EmailDto,
     BulkIssuanceProcessor,
-    AzureStorageService,
     NATSClient,
     {
       provide: MICRO_SERVICE_NAME,

--- a/apps/issuance/src/issuance.service.ts
+++ b/apps/issuance/src/issuance.service.ts
@@ -66,7 +66,7 @@ import { convertUrlToDeepLinkUrl, getAgentUrl, paginator } from '@credebl/common
 import { InjectQueue } from '@nestjs/bull';
 import { Queue } from 'bull';
 import { FileUploadStatus, FileUploadType } from 'apps/api-gateway/src/enum';
-import { AzureStorageService } from '@credebl/azure-storage';
+import { STORAGE_SERVICE, StorageService } from '@credebl/storage';
 import { io } from 'socket.io-client';
 import { IIssuedCredentialSearchParams, IssueCredentialType } from 'apps/api-gateway/src/issuance/interfaces';
 import {
@@ -107,7 +107,7 @@ export class IssuanceService {
     @Inject(CACHE_MANAGER) private readonly cacheManager: Cache,
     private readonly outOfBandIssuance: OutOfBandIssuance,
     private readonly emailData: EmailDto,
-    private readonly azureStorageService: AzureStorageService,
+    @Inject(STORAGE_SERVICE) private readonly storageService: StorageService,
     @InjectQueue('bulk-issuance') private readonly bulkIssuanceQueue: Queue,
     // TODO: Remove duplicate, unused variable
     @Inject(CACHE_MANAGER) private readonly cacheService: Cache,
@@ -1296,7 +1296,7 @@ export class IssuanceService {
         credentialPayload.schemaName = credentialDetails.schemaName;
       }
 
-      const getFileDetails = await this.azureStorageService.getFileByKey(importFileDetails.fileKey);
+      const getFileDetails = await this.storageService.getFileByKey(importFileDetails.fileKey);
       const csvData: string = getFileDetails.toString();
 
       const parsedData = paParse(csvData, {

--- a/apps/organization/src/organization.module.ts
+++ b/apps/organization/src/organization.module.ts
@@ -18,7 +18,7 @@ import { getNatsOptions } from '@credebl/common/nats.config';
 import { ClientRegistrationService } from '@credebl/client-registration';
 import { KeycloakUrlService } from '@credebl/keycloak-url';
 
-import { AzureStorageService } from '@credebl/azure-storage';
+import { StorageModule } from '@credebl/storage';
 import { CommonConstants } from '@credebl/common/common.constant';
 import { GlobalConfigModule } from '@credebl/config/global-config.module';
 import { ConfigModule as PlatformConfig } from '@credebl/config/config.module';
@@ -39,6 +39,7 @@ import { NATSClient } from '@credebl/common/NATSClient';
       }
     ]),
     CommonModule,
+    StorageModule,
     GlobalConfigModule,
     LoggerModule,
     PlatformConfig,
@@ -61,7 +62,6 @@ import { NATSClient } from '@credebl/common/NATSClient';
     UserActivityService,
     ClientRegistrationService,
     KeycloakUrlService,
-    AzureStorageService,
     NATSClient
   ],
   exports: [OrganizationRepository]

--- a/apps/organization/src/organization.service.ts
+++ b/apps/organization/src/organization.service.ts
@@ -42,7 +42,7 @@ import { UserActivityService } from '@credebl/user-activity';
 import { ClientRegistrationService } from '@credebl/client-registration/client-registration.service';
 import { map } from 'rxjs/operators';
 import { Cache } from 'cache-manager';
-import { AzureStorageService } from '@credebl/azure-storage';
+import { STORAGE_SERVICE, StorageService } from '@credebl/storage';
 import { CACHE_MANAGER } from '@nestjs/cache-manager';
 import {
   IOrgCredentials,
@@ -77,7 +77,7 @@ export class OrganizationService {
     private readonly organizationRepository: OrganizationRepository,
     private readonly orgRoleService: OrgRolesService,
     private readonly userOrgRoleService: UserOrgRolesService,
-    private readonly azureStorageService: AzureStorageService,
+    @Inject(STORAGE_SERVICE) private readonly storageService: StorageService,
     private readonly userActivityService: UserActivityService,
     private readonly logger: Logger,
     // TODO: Remove duplicate, unused variable
@@ -497,11 +497,12 @@ export class OrganizationService {
     try {
       const updatedOrglogo = orgLogo.split(',')[1];
       const imgData = Buffer.from(updatedOrglogo, 'base64');
-      const logoUrl = await this.azureStorageService.uploadUserCertificate(
+      const logoUrl = await this.storageService.uploadUserCertificate(
         imgData,
         'png',
         'orgLogo',
-        process.env.AZURE_STORAGE_CONTAINER_NAME || 'logo',
+        // Provider-agnostic: each provider resolves its own logo container/bucket.
+        undefined,
         'base64',
         'orgLogos'
       );

--- a/apps/user/src/fido/fido.module.ts
+++ b/apps/user/src/fido/fido.module.ts
@@ -19,7 +19,6 @@ import { UserOrgRolesRepository } from 'libs/user-org-roles/repositories';
 import { UserOrgRolesService } from '@credebl/user-org-roles';
 import { UserRepository } from '../../repositories/user.repository';
 import { UserService } from '../user.service';
-import { AzureStorageService } from '@credebl/azure-storage';
 import { NATSClient } from '@credebl/common/NATSClient';
 
 @Module({
@@ -38,7 +37,6 @@ import { NATSClient } from '@credebl/common/NATSClient';
 ],
   controllers: [FidoController],
   providers: [
-    AzureStorageService,
     UserService,
     PrismaService,
     FidoService,

--- a/apps/user/src/user.module.ts
+++ b/apps/user/src/user.module.ts
@@ -2,7 +2,6 @@ import { ClientsModule, Transport } from '@nestjs/microservices';
 import { Logger, Module } from '@nestjs/common';
 import { OrgRolesModule, OrgRolesService } from '@credebl/org-roles';
 
-import { AzureStorageService } from '@credebl/azure-storage';
 import { ClientRegistrationService } from '@credebl/client-registration';
 import { CommonConstants } from '@credebl/common/common.constant';
 import { CommonModule } from '@credebl/common';
@@ -46,7 +45,6 @@ import { getNatsOptions } from '@credebl/common/nats.config';
   ],
   controllers: [UserController],
   providers: [
-    AzureStorageService,
     UserService,
     UserRepository,
     PrismaService,

--- a/apps/user/src/user.service.ts
+++ b/apps/user/src/user.service.ts
@@ -53,7 +53,6 @@ import { v4 as uuidv4 } from 'uuid';
 import { Invitation, ProviderType, SessionType, TokenType, UserRole } from '@credebl/enum/enum';
 import validator from 'validator';
 import { DISALLOWED_EMAIL_DOMAIN } from '@credebl/common/common.constant';
-import { AzureStorageService } from '@credebl/azure-storage';
 import { IUsersActivity } from 'libs/user-activity/interface';
 import {
   ISendVerificationEmail,
@@ -83,7 +82,6 @@ export class UserService {
     private readonly userOrgRoleService: UserOrgRolesService,
     private readonly userActivityService: UserActivityService,
     private readonly userRepository: UserRepository,
-    private readonly azureStorageService: AzureStorageService,
     private readonly userDevicesRepository: UserDevicesRepository,
     private readonly logger: Logger,
     @Inject('NATS_CLIENT') private readonly userServiceProxy: ClientProxy,

--- a/apps/utility/src/utilities.module.ts
+++ b/apps/utility/src/utilities.module.ts
@@ -7,7 +7,7 @@ import { PrismaService } from '@credebl/prisma-service';
 import { UtilitiesController } from './utilities.controller';
 import { UtilitiesService } from './utilities.service';
 import { UtilitiesRepository } from './utilities.repository';
-import { AzureStorageService } from '@credebl/azure-storage';
+import { StorageModule } from '@credebl/storage';
 import { CommonConstants } from '@credebl/common/common.constant';
 import { GlobalConfigModule } from '@credebl/config/global-config.module';
 import { ConfigModule as PlatformConfig } from '@credebl/config/config.module';
@@ -28,6 +28,7 @@ import { ContextInterceptorModule } from '@credebl/context/contextInterceptorMod
       }
     ]),
     CommonModule,
+    StorageModule,
     GlobalConfigModule,
     LoggerModule,
     PlatformConfig,
@@ -35,6 +36,6 @@ import { ContextInterceptorModule } from '@credebl/context/contextInterceptorMod
     CacheModule.register()
   ],
   controllers: [UtilitiesController],
-  providers: [UtilitiesService, Logger, PrismaService, UtilitiesRepository, AzureStorageService]
+  providers: [UtilitiesService, Logger, PrismaService, UtilitiesRepository]
 })
 export class UtilitiesModule {}

--- a/apps/utility/src/utilities.service.ts
+++ b/apps/utility/src/utilities.service.ts
@@ -75,7 +75,7 @@ export class UtilitiesService extends BaseService {
     } catch (error) {
       this.logger.error(error);
       throw new Error(
-        `An error occurred while uploading data to Azure storage: ${error instanceof Error ? error?.message : error}`
+        `An error occurred while uploading data to storage: ${error instanceof Error ? error?.message : error}`
       );
     }
   }

--- a/apps/utility/src/utilities.service.ts
+++ b/apps/utility/src/utilities.service.ts
@@ -1,6 +1,6 @@
-import { Injectable, NotFoundException } from '@nestjs/common';
+import { Inject, Injectable, NotFoundException } from '@nestjs/common';
 
-import { AzureStorageService } from '@credebl/azure-storage';
+import { STORAGE_SERVICE, StorageService } from '@credebl/storage';
 import { BaseService } from 'libs/service/base.service';
 import { EmailDto } from '@credebl/common/dtos/email.dto';
 import { EmailService } from '@credebl/common/email.service';
@@ -16,7 +16,7 @@ export class UtilitiesService extends BaseService {
 
   constructor(
     private readonly utilitiesRepository: UtilitiesRepository,
-    private readonly azureStorageService: AzureStorageService,
+    @Inject(STORAGE_SERVICE) private readonly storageService: StorageService,
     private readonly emailService: EmailService
   ) {
     super('UtilitiesService');
@@ -65,7 +65,7 @@ export class UtilitiesService extends BaseService {
   async storeObject(payload: { persistent: boolean; storeObj: unknown }): Promise<string> {
     try {
       const uuid = uuidv4();
-      const uploadResult = await this.azureStorageService.storeObject(
+      const uploadResult = await this.storageService.storeObject(
         payload.persistent,
         uuid,
         payload.storeObj

--- a/libs/aws/src/aws.service.ts
+++ b/libs/aws/src/aws.service.ts
@@ -1,10 +1,12 @@
+import type { IStorageUploadResult, StorageService } from '@credebl/storage/storage.interface';
+
 import { HttpException, HttpStatus, Injectable } from '@nestjs/common';
 import { RpcException } from '@nestjs/microservices';
 import { S3 } from 'aws-sdk';
 import { promisify } from 'util';
 
 @Injectable()
-export class AwsService {
+export class AwsService implements StorageService {
   private s3: S3;
   private s4: S3;
   private s3StoreObject: S3;
@@ -56,6 +58,33 @@ export class AwsService {
     }
   }
 
+  // StorageService: certificate / org-logo upload. The logical container maps to the S3 bucket
+  // (org-logo bucket by default), so callers stay provider-agnostic.
+  async uploadUserCertificate(
+    fileBuffer: Buffer,
+    ext: string,
+    filename: string,
+    containerName?: string,
+    encoding?: string,
+    pathPrefix = ''
+  ): Promise<string> {
+    const bucketName = containerName || process.env.AWS_ORG_LOGO_BUCKET_NAME || process.env.AWS_BUCKET;
+    return this.uploadFileToS3Bucket(fileBuffer, ext, filename, bucketName, encoding ?? 'base64', pathPrefix);
+  }
+
+  async uploadFile(fileBuffer: Buffer, filename: string, contentType = 'image/png', folder = ''): Promise<string> {
+    const bucketName = process.env.AWS_ORG_LOGO_BUCKET_NAME || process.env.AWS_BUCKET;
+    const timestamp = Date.now();
+    const key = folder ? `${folder}/${filename}-${timestamp}` : `${filename}-${timestamp}`;
+
+    try {
+      await this.s4.upload({ Bucket: bucketName, Key: key, Body: fileBuffer, ContentType: contentType }).promise();
+      return `https://${bucketName}.s3.${process.env.AWS_PUBLIC_REGION}.amazonaws.com/${key}`;
+    } catch (error) {
+      throw new HttpException(error, HttpStatus.SERVICE_UNAVAILABLE);
+    }
+  }
+
   async uploadCsvFile(key: string, body: unknown): Promise<void> {
     const params: AWS.S3.PutObjectRequest = {
       Bucket: process.env.AWS_BUCKET,
@@ -70,22 +99,27 @@ export class AwsService {
     }
   }
 
-  async getFile(key: string): Promise<AWS.S3.GetObjectOutput> {
+  async getFileByKey(key: string, containerName?: string): Promise<Buffer> {
     const params: AWS.S3.GetObjectRequest = {
-      Bucket: process.env.AWS_BUCKET,
+      Bucket: containerName || process.env.AWS_BUCKET,
       Key: key
     };
     try {
-      return this.s3.getObject(params).promise();
+      const data = await this.s3.getObject(params).promise();
+      return data.Body as Buffer;
     } catch (error) {
       throw new RpcException(error.response ? error.response : error);
     }
   }
 
-  async deleteFile(key: string): Promise<void> {
+  async getFile(location: string): Promise<Buffer> {
+    return this.getFileByKey(location);
+  }
+
+  async deleteFile(location: string): Promise<void> {
     const params: AWS.S3.DeleteObjectRequest = {
       Bucket: process.env.AWS_BUCKET,
-      Key: key
+      Key: location
     };
     try {
       await this.s3.deleteObject(params).promise();
@@ -94,7 +128,7 @@ export class AwsService {
     }
   }
 
-  async storeObject(persistent: boolean, key: string, body: unknown): Promise<S3.ManagedUpload.SendData> {
+  async storeObject(persistent: boolean, key: string, body: unknown): Promise<IStorageUploadResult> {
     const objKey: string = persistent.valueOf() ? `persist/${key}` : `default/${key}`;
     const buf = Buffer.from(JSON.stringify(body));
     const params: AWS.S3.PutObjectRequest = {
@@ -107,7 +141,7 @@ export class AwsService {
 
     try {
       const receivedData = await this.s3StoreObject.upload(params).promise();
-      return receivedData;
+      return { Key: receivedData.Key, Location: receivedData.Location };
     } catch (error) {
       throw new RpcException(error.response ? error.response : error);
     }

--- a/libs/aws/src/aws.service.ts
+++ b/libs/aws/src/aws.service.ts
@@ -1,4 +1,4 @@
-import type { IStorageUploadResult, StorageService } from '@credebl/storage/storage.interface';
+import type { IStorageUploadResult, StorageService } from '@credebl/common';
 
 import { HttpException, HttpStatus, Injectable } from '@nestjs/common';
 import { RpcException } from '@nestjs/microservices';

--- a/libs/azure-storage/src/azure-storage.service.ts
+++ b/libs/azure-storage/src/azure-storage.service.ts
@@ -1,4 +1,4 @@
-import type { IStorageUploadResult, StorageService } from '@credebl/storage/storage.interface';
+import type { IStorageUploadResult, StorageService } from '@credebl/common';
 
 import { BlobServiceClient, ContainerClient } from '@azure/storage-blob';
 import { HttpException, HttpStatus, Injectable, Logger } from '@nestjs/common';

--- a/libs/azure-storage/src/azure-storage.service.ts
+++ b/libs/azure-storage/src/azure-storage.service.ts
@@ -1,14 +1,11 @@
+import type { IStorageUploadResult, StorageService } from '@credebl/storage/storage.interface';
+
 import { BlobServiceClient, ContainerClient } from '@azure/storage-blob';
 import { HttpException, HttpStatus, Injectable, Logger } from '@nestjs/common';
 import { RpcException } from '@nestjs/microservices';
 
-export interface IStorageUploadResult {
-  Key: string;
-  Location: string;
-}
-
 @Injectable()
-export class AzureStorageService {
+export class AzureStorageService implements StorageService {
   private readonly logger = new Logger(AzureStorageService.name);
   private blobServiceClient: BlobServiceClient;
   private containerClient: ContainerClient;

--- a/libs/common/src/index.ts
+++ b/libs/common/src/index.ts
@@ -1,5 +1,6 @@
 export * from './common.module';
 export * from './common.service';
+export * from './storage.interface';
 export * from './nats.interceptor';
 export * from './utils/error-handler.util';
 export * from './utils/url-validator.util';

--- a/libs/common/src/storage.interface.ts
+++ b/libs/common/src/storage.interface.ts
@@ -6,8 +6,10 @@ export interface IStorageUploadResult {
 /**
  * Provider-agnostic object/blob storage contract. Both AwsService (S3) and
  * AzureStorageService implement this so consumers depend on the interface
- * (injected via the STORAGE_SERVICE token) rather than a concrete provider.
- * The shape mirrors the existing Azure service so consumer call sites are unchanged.
+ * (injected via the STORAGE_SERVICE token from @credebl/storage) rather than a
+ * concrete provider. Housed in @credebl/common — a neutral lib that imports
+ * neither storage provider — so aws/azure/storage libs can all reference it
+ * without a dependency cycle.
  */
 export interface StorageService {
   uploadUserCertificate(

--- a/libs/storage/package.json
+++ b/libs/storage/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@credebl/storage",
+  "main": "src/index",
+  "types": "src/index",
+  "version": "0.0.1",
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "pnpm run clean && pnpm run compile",
+    "clean": "rimraf ../../dist/libs/storage",
+    "compile": "tsc -p tsconfig.build.json",
+    "test": "jest"
+  },
+  "dependencies": {
+    "@nestjs/common": "catalog:",
+    "@nestjs/testing": "catalog:",
+    "@nestjs/microservices": "catalog:"
+  },
+  "devDependencies": {
+    "reflect-metadata": "^0.1.13",
+    "rimraf": "^4.4.0",
+    "typescript": "^5.1.6"
+  }
+}

--- a/libs/storage/src/index.ts
+++ b/libs/storage/src/index.ts
@@ -1,3 +1,3 @@
+export type { IStorageUploadResult, StorageService } from '@credebl/common';
 export * from './storage.constants';
-export * from './storage.interface';
 export * from './storage.module';

--- a/libs/storage/src/index.ts
+++ b/libs/storage/src/index.ts
@@ -1,0 +1,3 @@
+export * from './storage.constants';
+export * from './storage.interface';
+export * from './storage.module';

--- a/libs/storage/src/storage.constants.ts
+++ b/libs/storage/src/storage.constants.ts
@@ -1,0 +1,6 @@
+export const STORAGE_SERVICE = 'STORAGE_SERVICE';
+
+export enum StorageType {
+  AWS = 'aws',
+  AZURE = 'azure'
+}

--- a/libs/storage/src/storage.interface.ts
+++ b/libs/storage/src/storage.interface.ts
@@ -1,0 +1,27 @@
+export interface IStorageUploadResult {
+  Key: string;
+  Location: string;
+}
+
+/**
+ * Provider-agnostic object/blob storage contract. Both AwsService (S3) and
+ * AzureStorageService implement this so consumers depend on the interface
+ * (injected via the STORAGE_SERVICE token) rather than a concrete provider.
+ * The shape mirrors the existing Azure service so consumer call sites are unchanged.
+ */
+export interface StorageService {
+  uploadUserCertificate(
+    fileBuffer: Buffer,
+    ext: string,
+    filename: string,
+    containerName?: string,
+    encoding?: string,
+    pathPrefix?: string
+  ): Promise<string>;
+  uploadFile(fileBuffer: Buffer, filename: string, contentType?: string, folder?: string): Promise<string>;
+  uploadCsvFile(key: string, body: unknown): Promise<void>;
+  getFileByKey(key: string, containerName?: string): Promise<Buffer>;
+  getFile(location: string): Promise<Buffer>;
+  deleteFile(location: string): Promise<void>;
+  storeObject(persistent: boolean, key: string, body: unknown): Promise<IStorageUploadResult>;
+}

--- a/libs/storage/src/storage.module.ts
+++ b/libs/storage/src/storage.module.ts
@@ -6,20 +6,20 @@ import { STORAGE_SERVICE, StorageType } from './storage.constants';
 
 /**
  * Selects the storage provider from STORAGE_TYPE ('aws' | 'azure'), defaulting to
- * 'aws' when unset. Consumers import StorageModule and inject the STORAGE_SERVICE
- * token (typed as StorageService).
+ * 'aws' when unset. Resolved at instantiation time via a factory (not at module-load),
+ * reusing the AwsService/AzureStorageService instances from the imported modules.
+ * Consumers import StorageModule and inject the STORAGE_SERVICE token (typed as StorageService).
  */
-const resolveStorageProvider = (): typeof AwsService | typeof AzureStorageService => {
-  const storageType = (process.env.STORAGE_TYPE ?? StorageType.AWS).toLowerCase();
-  return storageType === StorageType.AZURE ? AzureStorageService : AwsService;
-};
-
 @Module({
   imports: [AwsModule, AzureStorageModule],
   providers: [
     {
       provide: STORAGE_SERVICE,
-      useClass: resolveStorageProvider()
+      useFactory: (aws: AwsService, azure: AzureStorageService): AwsService | AzureStorageService => {
+        const storageType = (process.env.STORAGE_TYPE ?? StorageType.AWS).toLowerCase();
+        return storageType === StorageType.AZURE ? azure : aws;
+      },
+      inject: [AwsService, AzureStorageService]
     }
   ],
   exports: [STORAGE_SERVICE]

--- a/libs/storage/src/storage.module.ts
+++ b/libs/storage/src/storage.module.ts
@@ -1,0 +1,27 @@
+import { AwsModule, AwsService } from '@credebl/aws';
+import { AzureStorageModule, AzureStorageService } from '@credebl/azure-storage';
+import { Module } from '@nestjs/common';
+
+import { STORAGE_SERVICE, StorageType } from './storage.constants';
+
+/**
+ * Selects the storage provider from STORAGE_TYPE ('aws' | 'azure'), defaulting to
+ * 'aws' when unset. Consumers import StorageModule and inject the STORAGE_SERVICE
+ * token (typed as StorageService).
+ */
+const resolveStorageProvider = (): typeof AwsService | typeof AzureStorageService => {
+  const storageType = (process.env.STORAGE_TYPE ?? StorageType.AWS).toLowerCase();
+  return storageType === StorageType.AZURE ? AzureStorageService : AwsService;
+};
+
+@Module({
+  imports: [AwsModule, AzureStorageModule],
+  providers: [
+    {
+      provide: STORAGE_SERVICE,
+      useClass: resolveStorageProvider()
+    }
+  ],
+  exports: [STORAGE_SERVICE]
+})
+export class StorageModule {}

--- a/libs/storage/tsconfig.build.json
+++ b/libs/storage/tsconfig.build.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.build.json",
+  "compilerOptions": {
+    "outDir": "../../dist/libs/storage"
+  },
+  "include": ["src/**/*"]
+}

--- a/libs/storage/tsconfig.json
+++ b/libs/storage/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {}
+}

--- a/libs/storage/tsconfig.lib.json
+++ b/libs/storage/tsconfig.lib.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "declaration": true,
+    "outDir": "../../dist/libs/storage"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "test", "**/*spec.ts"]
+}

--- a/nest-cli.json
+++ b/nest-cli.json
@@ -332,6 +332,15 @@
         "tsConfigPath": "libs/azure-storage/tsconfig.lib.json"
       }
     },
+    "storage": {
+      "type": "library",
+      "root": "libs/storage",
+      "entryFile": "index",
+      "sourceRoot": "libs/storage/src",
+      "compilerOptions": {
+        "tsConfigPath": "libs/storage/tsconfig.lib.json"
+      }
+    },
     "marketplace": {
       "type": "application",
       "root": "apps/marketplace",

--- a/package.json
+++ b/package.json
@@ -208,6 +208,7 @@
       "^@app/supabase(|/.*)$": "<rootDir>/libs/supabase/src/$1",
       "^@credebl/aws(|/.*)$": "<rootDir>/libs/aws/src/$1",
       "^@credebl/azure-storage(|/.*)$": "<rootDir>/libs/azure-storage/src/$1",
+      "^@credebl/storage(|/.*)$": "<rootDir>/libs/storage/src/$1",
       "^credebl/utility(|/.*)$": "<rootDir>/libs/utility/src/$1",
       "^@credebl/config(|/.*)$": "<rootDir>/libs/config/src/$1",
       "^@credebl/context(|/.*)$": "<rootDir>/libs/context/src/$1",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,6 +14,12 @@
       "@credebl/azure-storage/*": [
         "libs/azure-storage/src/*"
       ],
+      "@credebl/storage": [
+        "libs/storage/src"
+      ],
+      "@credebl/storage/*": [
+        "libs/storage/src/*"
+      ],
       "@credebl/client-registration": [
         "libs/client-registration/src"
       ],


### PR DESCRIPTION
## [General] Selectable AWS/Azure storage provider via `STORAGE_TYPE`

The phenix-id merge hard-swapped file/blob storage to **Azure** (concrete `AzureStorageService` injected everywhere; `libs/aws` left orphaned). This makes the provider **selectable** at runtime.

> **Correction to the migration plan (§4/Q5):** vanilla CREDEBL has **no** `STORAGE_TYPE` abstraction to "refactor Azure into" — it ships a single concrete `AwsService`. So the switch is **built** here, not adopted.

### What it does
- **New `libs/storage` (`@credebl/storage`)** — a `StorageService` interface (mirrors the existing Azure API, so consumer call sites are unchanged), a `STORAGE_SERVICE` DI token, and a `StorageModule` that binds the token to `AwsService` or `AzureStorageService` based on **`STORAGE_TYPE` (`aws` | `azure`), defaulting to `aws`**.
- **`AwsService`** re-aligned to implement `StorageService` (`getFileByKey`/`getFile` return `Buffer`, `storeObject` returns `{Key,Location}`, added `uploadUserCertificate`/`uploadFile`). **`AzureStorageService`** now `implements StorageService`. `IStorageUploadResult` moved to `libs/storage`. Both import the interface **type-only from the leaf file** to avoid an `aws`/`azure` ⇄ `storage` cycle.
- The **4 real storage consumers** (bulk-issuance CSV upload/read, org-logo upload, shortened-URL `storeObject`) now inject `STORAGE_SERVICE` via `StorageModule`; the org-logo call no longer passes an Azure-specific container (each provider resolves its own).
- `.env.demo` documents `STORAGE_TYPE` (default `aws`).

### ⚠ Behavior change
Default `aws` means any environment currently on Azure **without** `STORAGE_TYPE` set will use S3. **Set `STORAGE_TYPE=azure` explicitly** in those environments at cutover.

### Scope note
Only the 4 modules/consumers that actually use storage are switched. **6 modules provide `AzureStorageService` but never use it, and 2 constructors inject it unused** (pre-existing dead wiring) — left untouched here to keep the diff focused; can be cleaned up separately. The private helper `organization.service.ts#uploadFileToAzure` keeps its name (now provider-agnostic).

### Verification
- `tsc --noEmit`: **no new errors vs `develop` baseline** (109 = 109); no `implements`/token/`@credebl/storage`-resolution errors → interface conformance + DI typing are sound.
- ESLint clean on all new code (`libs/storage`, re-aligned `AwsService`); remaining lint errors in touched app files are pre-existing (`implicit-arrow-linebreak`, unrelated lines).
- ⚠ **Full `nest build` could not be completed in this working copy** because `@azure/storage-blob` is not installed (workspace deps are partial) — **identical failure on `develop`**, i.e. a pre-existing environment gap, not introduced here. Must be built + **runtime-smoke-tested in a fully-installed env** (CI/staging): with `STORAGE_TYPE=aws` and `=azure`, exercise bulk-CSV upload/read, org-logo upload, shortened-URL create/resolve; confirm unset ⇒ `aws`.

Base: `develop`
