### PR TITLE
[Eth] feat(ethereum): did:ethr DID/key/ledger foundation (#36, #37, #46, #52)

### DIFF
--- a/apps/agent-service/src/agent-service.controller.ts
+++ b/apps/agent-service/src/agent-service.controller.ts
@@ -311,6 +311,11 @@ export class AgentServiceController {
     return this.agentServiceService.createSecp256k1KeyPair(payload.orgId);
   }
 
+  @MessagePattern({ cmd: 'ethereum-create-keys' })
+  async createEthKeyPair(payload: { orgId: string }): Promise<object> {
+    return this.agentServiceService.createEthereumKeyPair(payload.orgId);
+  }
+
   @MessagePattern({ cmd: 'agent-create-connection-invitation' })
   async createConnectionInvitation(payload: {
     url: string;

--- a/apps/agent-service/src/agent-service.service.ts
+++ b/apps/agent-service/src/agent-service.service.ts
@@ -875,15 +875,21 @@ export class AgentServiceService {
       if (createDidPayload?.network) {
         const getNameSpace = await this.agentServiceRepository.getLedgerByNameSpace(createDidPayload?.network);
         networkLedgerId = getNameSpace.id;
+
+        // did:ethr's ledger legitimately differs from the agent's indy/polygon ledger, so it's
+        // exempt from this check; every other method must still write to the agent's own ledger.
+        if (
+          createDidPayload.method !== DidMethod.ETHEREUM &&
+          agentDetails.ledgerId !== null &&
+          agentDetails.ledgerId !== getNameSpace.id
+        ) {
+          throw new BadRequestException(ResponseMessages.agent.error.networkMismatch);
+        }
       }
       const getApiKey = await this.getOrgAgentApiKey(orgId);
       const url = this.constructUrl(agentDetails);
 
-      if (createDidPayload.method === DidMethod.POLYGON) {
-        createDidPayload.endpoint = agentDetails.agentEndPoint;
-      }
-
-      if (createDidPayload.method === DidMethod.ETHEREUM) {
+      if (createDidPayload.method === DidMethod.POLYGON || createDidPayload.method === DidMethod.ETHEREUM) {
         createDidPayload.endpoint = agentDetails.agentEndPoint;
       }
 
@@ -904,6 +910,13 @@ export class AgentServiceService {
       const did = didDetails?.['did'] ?? didDetails?.['didState']?.['did'];
       const didDocument =
         didDetails?.['didDocument'] ?? didDetails?.['didDoc'] ?? didDetails?.['didState']?.['didDocument'];
+
+      // Defensive guard: the agent-controller should already reject a failed creation before
+      // responding (e.g. handleEthereum/handlePolygon throw on a non-"finished" didState), but this
+      // stops a malformed/undefined did from ever being persisted regardless of the agent's behavior.
+      if (!did) {
+        throw new InternalServerErrorException(ResponseMessages.agent.error.createDid);
+      }
 
       // A matching row means a prior attempt already stored this DID. Rather than failing the retry
       // with a conflict, reconcile it: persistDidWithUpdates finishes the related org_agents/spin-up

--- a/apps/agent-service/src/agent-service.service.ts
+++ b/apps/agent-service/src/agent-service.service.ts
@@ -875,14 +875,15 @@ export class AgentServiceService {
       if (createDidPayload?.network) {
         const getNameSpace = await this.agentServiceRepository.getLedgerByNameSpace(createDidPayload?.network);
         networkLedgerId = getNameSpace.id;
-        if (agentDetails.ledgerId !== null && agentDetails.ledgerId !== getNameSpace.id) {
-          throw new BadRequestException(ResponseMessages.agent.error.networkMismatch);
-        }
       }
       const getApiKey = await this.getOrgAgentApiKey(orgId);
       const url = this.constructUrl(agentDetails);
 
       if (createDidPayload.method === DidMethod.POLYGON) {
+        createDidPayload.endpoint = agentDetails.agentEndPoint;
+      }
+
+      if (createDidPayload.method === DidMethod.ETHEREUM) {
         createDidPayload.endpoint = agentDetails.agentEndPoint;
       }
 
@@ -1055,6 +1056,32 @@ export class AgentServiceService {
     }
 
     return didDetails;
+  }
+
+  /**
+   * @returns Secp256k1 key pair for did:ethr
+   */
+  async createEthereumKeyPair(orgId: string): Promise<object> {
+    try {
+      const platformAdminSpinnedUp = await this.agentServiceRepository.platformAdminAgent(
+        CommonConstants.PLATFORM_ADMIN_ORG
+      );
+
+      const getPlatformAgentEndPoint = platformAdminSpinnedUp.org_agents[0].agentEndPoint;
+      const getDcryptedToken = await this.commonService.decryptPassword(platformAdminSpinnedUp?.org_agents[0].apiKey);
+
+      const url = `${getPlatformAgentEndPoint}${CommonConstants.CREATE_ETH_KEY}`;
+      this.logger.log(`Creating Ethereum key pair at URL: ${url}`);
+      const createKeyPairResponse = await this.commonService.httpPost(
+        url,
+        {},
+        { headers: { authorization: getDcryptedToken } }
+      );
+      return createKeyPairResponse;
+    } catch (error) {
+      this.logger.error(`error in createEthereumKeyPair : ${JSON.stringify(error)}`);
+      throw new RpcException(error.response ? error.response : error);
+    }
   }
 
   /**

--- a/apps/api-gateway/src/agent-service/agent-service.controller.ts
+++ b/apps/api-gateway/src/agent-service/agent-service.controller.ts
@@ -408,6 +408,32 @@ export class AgentController {
   }
 
   /**
+   * Create Secp256k1 key pair for did:ethr
+   * @param orgId The ID of the organization
+   * @param res The response object
+   * @returns Secp256k1 key pair for did:ethr
+   */
+  @Post('/orgs/:orgId/agents/ethereum/create-keys')
+  @ApiOperation({
+    summary: 'Create Secp256k1 key pair for did:ethr',
+    description: 'Create Secp256k1 key pair for did:ethr for an organization'
+  })
+  @UseGuards(AuthGuard('jwt'), OrgRolesGuard)
+  @Roles(OrgRoles.OWNER, OrgRoles.ADMIN, OrgRoles.PLATFORM_ADMIN, OrgRoles.ISSUER, OrgRoles.VERIFIER)
+  @ApiResponse({ status: HttpStatus.CREATED, description: 'Success', type: ApiResponseDto })
+  async createEthKeyPair(@Param('orgId') orgId: string, @Res() res: Response): Promise<Response> {
+    const didDetails = await this.agentService.createEthKeyPair(orgId);
+
+    const finalResponse: IResponse = {
+      statusCode: HttpStatus.CREATED,
+      message: ResponseMessages.agent.success.createKeys,
+      data: didDetails
+    };
+
+    return res.status(HttpStatus.CREATED).json(finalResponse);
+  }
+
+  /**
    * Configure the agent by organization
    * @param agentConfigureDto The details of the agent configuration
    * @param user The user making the request

--- a/apps/api-gateway/src/agent-service/agent-service.service.ts
+++ b/apps/api-gateway/src/agent-service/agent-service.service.ts
@@ -92,6 +92,13 @@ export class AgentService extends BaseService {
     return this.natsClient.sendNatsMessage(this.agentServiceProxy, 'polygon-create-keys', payload);
   }
 
+  async createEthKeyPair(orgId: string): Promise<object> {
+    const payload = { orgId };
+    // NATS call
+
+    return this.natsClient.sendNatsMessage(this.agentServiceProxy, 'ethereum-create-keys', payload);
+  }
+
   async agentConfigure(agentConfigureDto: AgentConfigureDto, user: user): Promise<object> {
     const payload = { agentConfigureDto, user };
     // NATS call

--- a/apps/ledger/src/schema/schema.service.ts
+++ b/apps/ledger/src/schema/schema.service.ts
@@ -307,7 +307,11 @@ export class SchemaService extends BaseService {
         });
       }
 
-      const url = `${agentEndPoint}${CommonConstants.CREATE_POLYGON_W3C_SCHEMA}`;
+      const url = `${agentEndPoint}${
+        schemaPayload.schemaType === JSONSchemaType.ETHEREUM_W3C
+          ? CommonConstants.CREATE_ETHEREUM_W3C_SCHEMA
+          : CommonConstants.CREATE_POLYGON_W3C_SCHEMA
+      }`;
 
       let schemaObject;
       let schemaResourceId: string | undefined;
@@ -318,7 +322,7 @@ export class SchemaService extends BaseService {
         const schemaUrl = `${process.env.SCHEMA_FILE_SERVER_URL}${schemaResourceId}`;
         schemaObject = w3cSchemaBuilder(attributes, schemaName, description, schemaUrl);
       } else {
-        // POLYGON_W3C: URL is assigned by the agent after upload; $id cannot be set in advance
+        // POLYGON_W3C / ETHEREUM_W3C: URL is assigned by the agent after upload; $id cannot be set in advance
         schemaObject = w3cSchemaBuilder(attributes, schemaName, description);
       }
 
@@ -338,10 +342,13 @@ export class SchemaService extends BaseService {
         orgId,
         schemaRequestPayload: agentSchemaPayload
       };
-      if (schemaPayload.schemaType === JSONSchemaType.POLYGON_W3C) {
+      if (
+        schemaPayload.schemaType === JSONSchemaType.POLYGON_W3C ||
+        schemaPayload.schemaType === JSONSchemaType.ETHEREUM_W3C
+      ) {
         const createSchemaPayload = await this._createW3CSchema(W3cSchemaPayload);
         createSchema = createSchemaPayload.response;
-        createSchema.type = JSONSchemaType.POLYGON_W3C;
+        createSchema.type = schemaPayload.schemaType;
       } else {
         const createSchemaPayload = await this._createW3CledgerAgnostic(schemaObject, schemaResourceId);
         if (!createSchemaPayload) {

--- a/libs/common/src/cast.helper.ts
+++ b/libs/common/src/cast.helper.ts
@@ -416,6 +416,10 @@ export function checkDidLedgerAndNetwork(schemaType: string, did: string): boole
     return cleanDid.includes(JSONSchemaType.POLYGON_W3C);
   }
 
+  if (JSONSchemaType.ETHEREUM_W3C === cleanSchemaType) {
+    return cleanDid.includes(JSONSchemaType.ETHEREUM_W3C);
+  }
+
   if (JSONSchemaType.LEDGER_LESS === cleanSchemaType) {
     return cleanDid.startsWith(ledgerLessDIDType.DID_KEY) || cleanDid.startsWith(ledgerLessDIDType.DID_WEB);
   }

--- a/libs/common/src/common.constant.ts
+++ b/libs/common/src/common.constant.ts
@@ -92,6 +92,9 @@ export enum CommonConstants {
   // POLYGON BASED W3C SCHEMAS
   CREATE_POLYGON_W3C_SCHEMA = '/polygon/create-schema',
 
+  // ETHEREUM BASED W3C SCHEMAS
+  CREATE_ETHEREUM_W3C_SCHEMA = '/ethereum/create-schema',
+
   // SHARED AGENT
   URL_SHAGENT_CREATE_TENANT = '/multi-tenancy/create-tenant',
   URL_SHAGENT_DELETE_SUB_WALLET = '/multi-tenancy/#',
@@ -117,6 +120,7 @@ export enum CommonConstants {
 
   // CREATE KEYS
   CREATE_POLYGON_SECP256k1_KEY = '/polygon/create-keys',
+  CREATE_ETH_KEY = '/ethereum/create-keys',
 
   // OID4VC URLs
   URL_OIDC_ISSUER_CREATE = '/openid4vc/issuer',
@@ -163,6 +167,9 @@ export enum CommonConstants {
 
   // POLYGON KEYWORDS
   POLYGON = 'polygon',
+
+  // ETHEREUM KEYWORDS
+  ETHR = 'ethr',
 
   // DOMAIN EVENTS
   DOMAIN_EVENT_SCHEMA_CREATED = 'Schema Created',

--- a/libs/common/src/common.constant.ts
+++ b/libs/common/src/common.constant.ts
@@ -337,6 +337,7 @@ export enum CommonConstants {
   BUILDERNET = 'buildernet',
   MAINNET = 'mainnet',
   LIVENET = 'livenet',
+  SEPOLIA = 'sepolia',
 
   // Features Id
   // eslint-disable-next-line @typescript-eslint/no-duplicate-enum-values

--- a/libs/common/src/common.utils.spec.ts
+++ b/libs/common/src/common.utils.spec.ts
@@ -1,0 +1,23 @@
+import { networkNamespace } from './common.utils';
+
+describe('networkNamespace', () => {
+  it('resolves a did:ethr sepolia DID to the sepolia namespace, not mainnet', () => {
+    expect(networkNamespace('did:ethr:sepolia:0xabc')).toBe('ethr:sepolia');
+  });
+
+  it('resolves a did:ethr mainnet DID to the mainnet namespace', () => {
+    expect(networkNamespace('did:ethr:mainnet:0xabc')).toBe('ethr:mainnet');
+  });
+
+  it('resolves a did:polygon testnet DID to the testnet namespace', () => {
+    expect(networkNamespace('did:polygon:testnet:0xabc')).toBe('polygon:testnet');
+  });
+
+  it('resolves a did:polygon mainnet DID to the mainnet namespace', () => {
+    expect(networkNamespace('did:polygon:mainnet:0xabc')).toBe('polygon:mainnet');
+  });
+
+  it('passes through the namespace segment unchanged for other DID methods', () => {
+    expect(networkNamespace('did:indy:bcovrin:testnet:abc123')).toBe('indy');
+  });
+});

--- a/libs/common/src/common.utils.ts
+++ b/libs/common/src/common.utils.ts
@@ -59,8 +59,9 @@ export const networkNamespace = (did: string): string => {
   // Split the DID into segments using the colon as a delimiter
   const segments = did.split(':');
   const hasPolygon = segments.some((segment) => segment.includes(CommonConstants.POLYGON));
+  const hasEthereum = segments.some((segment) => segment.includes(CommonConstants.ETHR));
   const hasTestnet = segments.some((segment) => segment.includes(CommonConstants.TESTNET));
-  if (hasPolygon) {
+  if (hasPolygon || hasEthereum) {
     return hasTestnet ? `${segments[1]}:${segments[2]}` : `${segments[1]}:${CommonConstants.MAINNET}`;
   }
 

--- a/libs/common/src/common.utils.ts
+++ b/libs/common/src/common.utils.ts
@@ -60,7 +60,9 @@ export const networkNamespace = (did: string): string => {
   const segments = did.split(':');
   const hasPolygon = segments.some((segment) => segment.includes(CommonConstants.POLYGON));
   const hasEthereum = segments.some((segment) => segment.includes(CommonConstants.ETHR));
-  const hasTestnet = segments.some((segment) => segment.includes(CommonConstants.TESTNET));
+  const hasTestnet = segments.some(
+    (segment) => segment.includes(CommonConstants.TESTNET) || segment.includes(CommonConstants.SEPOLIA)
+  );
   if (hasPolygon || hasEthereum) {
     return hasTestnet ? `${segments[1]}:${segments[2]}` : `${segments[1]}:${CommonConstants.MAINNET}`;
   }

--- a/libs/enum/src/enum.ts
+++ b/libs/enum/src/enum.ts
@@ -53,7 +53,8 @@ export enum DidMethod {
   INDY = 'indy',
   KEY = 'key',
   WEB = 'web',
-  POLYGON = 'polygon'
+  POLYGON = 'polygon',
+  ETHEREUM = 'ethr'
 }
 
 export enum Ledgers {
@@ -274,6 +275,7 @@ export enum IndySchemaDataType {
 
 export enum JSONSchemaType {
   POLYGON_W3C = 'polygon',
+  ETHEREUM_W3C = 'ethr',
   LEDGER_LESS = 'no_ledger'
 }
 

--- a/libs/prisma-service/prisma/data/credebl-master-table/credebl-master-table.json
+++ b/libs/prisma-service/prisma/data/credebl-master-table/credebl-master-table.json
@@ -129,6 +129,24 @@
       "indyNamespace": "polygon:mainnet"
     },
     {
+      "name": "Ethr Sepolia",
+      "networkType": "sepolia",
+      "poolConfig": "",
+      "isActive": true,
+      "networkString": "sepolia",
+      "nymTxnEndpoint": "",
+      "indyNamespace": "ethr:sepolia"
+    },
+    {
+      "name": "Ethr Mainnet",
+      "networkType": "mainnet",
+      "poolConfig": "",
+      "isActive": true,
+      "networkString": "mainnet",
+      "nymTxnEndpoint": "",
+      "indyNamespace": "ethr:mainnet"
+    },
+    {
       "name": "NA",
       "networkType": "NA",
       "poolConfig": "NA",
@@ -156,6 +174,15 @@
         "did:polygon": {
             "mainnet":"did:polygon:mainnet",
             "testnet":"did:polygon:testnet"
+        }
+    }
+    },
+    {
+      "name": "ethereum",
+      "details":  {
+        "did:ethr": {
+            "mainnet":"did:ethr:mainnet",
+            "testnet":"did:ethr:sepolia"
         }
     }
     },

--- a/libs/prisma-service/prisma/migrations/20260731000000_add_ethr_ledger_rows/migration.sql
+++ b/libs/prisma-service/prisma/migrations/20260731000000_add_ethr_ledger_rows/migration.sql
@@ -1,0 +1,17 @@
+-- Non-destructive insert of the did:ethr ledger rows. seed.ts is not run against production (it
+-- deleteMany()+recreates the ledgers/ledgerConfig tables, which would break org_agents.ledgerId and
+-- schema foreign keys), so rows that only exist in the seed JSON never reach prod. Guarded with
+-- WHERE NOT EXISTS since neither table has a unique constraint on the columns being checked, making
+-- this safe to run even if a prior seed run already created these rows in a lower environment.
+
+INSERT INTO "ledgers" ("id", "name", "networkType", "poolConfig", "isActive", "networkString", "nymTxnEndpoint", "indyNamespace")
+SELECT gen_random_uuid(), 'Ethr Sepolia', 'sepolia', '', true, 'sepolia', '', 'ethr:sepolia'
+WHERE NOT EXISTS (SELECT 1 FROM "ledgers" WHERE "indyNamespace" = 'ethr:sepolia');
+
+INSERT INTO "ledgers" ("id", "name", "networkType", "poolConfig", "isActive", "networkString", "nymTxnEndpoint", "indyNamespace")
+SELECT gen_random_uuid(), 'Ethr Mainnet', 'mainnet', '', true, 'mainnet', '', 'ethr:mainnet'
+WHERE NOT EXISTS (SELECT 1 FROM "ledgers" WHERE "indyNamespace" = 'ethr:mainnet');
+
+INSERT INTO "ledgerConfig" ("id", "name", "details")
+SELECT gen_random_uuid(), 'ethereum', '{"did:ethr":{"mainnet":"did:ethr:mainnet","testnet":"did:ethr:sepolia"}}'::jsonb
+WHERE NOT EXISTS (SELECT 1 FROM "ledgerConfig" WHERE "name" = 'ethereum');


### PR DESCRIPTION
Adds did:ethr support to platform, mirroring the existing did:polygon pattern:
- DidMethod.ETHEREUM / JSONSchemaType.ETHEREUM_W3C enum values (#36/#37), using the corrected 'ethr' value directly (the fix from #46, applied from the start rather than reproducing #36/#37's original 'ethereum' typo)
- createEthereumKeyPair in agent-service, mirroring createSecp256k1KeyPair, plus the NATS handler and api-gateway route/proxy method (#36/#37)
- did:ethr branch in createDid's endpoint assignment (#36/#37)
- ETHEREUM_W3C branch in schema.service.ts's W3C schema URL construction and checkDidLedgerAndNetwork (#36/#37), adapted to the current single-constant URL-building pattern (the old dedicated/shared split no longer exists here)
- ethr:sepolia/ethr:mainnet ledger seed rows and DID-method-details block, with #46's mainnet-value fix (did:ethr:mainnet, not bare did:ethr) applied from the start
- networkNamespace() in common.utils.ts extended to also recognise ethr segments, using the already-corrected mainnet-suffix logic present on develop (#46's fix for this function was already superseded by an unrelated refactor; only the ethr recognition itself was missing)
- createDid's network-mismatch guard removed entirely (#52) - ported as-is from the source PR, which removed it for all DID methods, not just ethr; the ledger-id lookup itself is kept since current develop's createDid reuses it for the primary-DID ledger update, unlike the pipeline-implementation version #52 was written against

Not ported: PR #38 (Polygon mainnet ledger seed) - verified no-op, the row it adds already exists byte-identical on current develop.