### PR TITLE
[Eth] feat(schema): did:ethr schema migration (#50, #53, #54)

### DIFF
--- a/apps/agent-service/src/agent-service.controller.ts
+++ b/apps/agent-service/src/agent-service.controller.ts
@@ -92,6 +92,11 @@ export class AgentServiceController {
     return this.agentServiceService.createW3CSchema(payload.url, payload.orgId, payload.schemaRequestPayload);
   }
 
+  @MessagePattern({ cmd: 'agent-migrate-w3c-schema' })
+  async migrateW3CSchema(payload: { url; orgId; schemaRequestPayload }): Promise<object> {
+    return this.agentServiceService.migrateW3CSchema(payload.url, payload.orgId, payload.schemaRequestPayload);
+  }
+
   //DONE
   @MessagePattern({ cmd: 'agent-get-schema' })
   async getSchemaById(payload: IGetSchemaAgentRedirection): Promise<object> {

--- a/apps/agent-service/src/agent-service.controller.ts
+++ b/apps/agent-service/src/agent-service.controller.ts
@@ -311,6 +311,11 @@ export class AgentServiceController {
     return this.agentServiceService.createSecp256k1KeyPair(payload.orgId);
   }
 
+  @MessagePattern({ cmd: 'ethereum-create-keys' })
+  async createEthKeyPair(payload: { orgId: string }): Promise<object> {
+    return this.agentServiceService.createEthereumKeyPair(payload.orgId);
+  }
+
   @MessagePattern({ cmd: 'agent-create-connection-invitation' })
   async createConnectionInvitation(payload: {
     url: string;

--- a/apps/agent-service/src/agent-service.service.ts
+++ b/apps/agent-service/src/agent-service.service.ts
@@ -875,15 +875,21 @@ export class AgentServiceService {
       if (createDidPayload?.network) {
         const getNameSpace = await this.agentServiceRepository.getLedgerByNameSpace(createDidPayload?.network);
         networkLedgerId = getNameSpace.id;
+
+        // did:ethr's ledger legitimately differs from the agent's indy/polygon ledger, so it's
+        // exempt from this check; every other method must still write to the agent's own ledger.
+        if (
+          createDidPayload.method !== DidMethod.ETHEREUM &&
+          agentDetails.ledgerId !== null &&
+          agentDetails.ledgerId !== getNameSpace.id
+        ) {
+          throw new BadRequestException(ResponseMessages.agent.error.networkMismatch);
+        }
       }
       const getApiKey = await this.getOrgAgentApiKey(orgId);
       const url = this.constructUrl(agentDetails);
 
-      if (createDidPayload.method === DidMethod.POLYGON) {
-        createDidPayload.endpoint = agentDetails.agentEndPoint;
-      }
-
-      if (createDidPayload.method === DidMethod.ETHEREUM) {
+      if (createDidPayload.method === DidMethod.POLYGON || createDidPayload.method === DidMethod.ETHEREUM) {
         createDidPayload.endpoint = agentDetails.agentEndPoint;
       }
 
@@ -904,6 +910,13 @@ export class AgentServiceService {
       const did = didDetails?.['did'] ?? didDetails?.['didState']?.['did'];
       const didDocument =
         didDetails?.['didDocument'] ?? didDetails?.['didDoc'] ?? didDetails?.['didState']?.['didDocument'];
+
+      // Defensive guard: the agent-controller should already reject a failed creation before
+      // responding (e.g. handleEthereum/handlePolygon throw on a non-"finished" didState), but this
+      // stops a malformed/undefined did from ever being persisted regardless of the agent's behavior.
+      if (!did) {
+        throw new InternalServerErrorException(ResponseMessages.agent.error.createDid);
+      }
 
       // A matching row means a prior attempt already stored this DID. Rather than failing the retry
       // with a conflict, reconcile it: persistDidWithUpdates finishes the related org_agents/spin-up

--- a/apps/agent-service/src/agent-service.service.ts
+++ b/apps/agent-service/src/agent-service.service.ts
@@ -2237,6 +2237,19 @@ export class AgentServiceService {
     }
   }
 
+  async migrateW3CSchema(url: string, orgId: string, schemaRequestPayload): Promise<object> {
+    try {
+      const getApiKey = await this.getOrgAgentApiKey(orgId);
+      const schemaRequest = await this.commonService
+        .httpPost(url, schemaRequestPayload, { headers: { authorization: getApiKey } })
+        .then(async (response) => response);
+      return schemaRequest;
+    } catch (error) {
+      this.logger.error(`Error in migrateW3CSchema request in agent service : ${JSON.stringify(error)}`);
+      throw error;
+    }
+  }
+
   async createConnectionInvitation(
     url: string,
     orgId: string,

--- a/apps/agent-service/src/agent-service.service.ts
+++ b/apps/agent-service/src/agent-service.service.ts
@@ -875,14 +875,15 @@ export class AgentServiceService {
       if (createDidPayload?.network) {
         const getNameSpace = await this.agentServiceRepository.getLedgerByNameSpace(createDidPayload?.network);
         networkLedgerId = getNameSpace.id;
-        if (agentDetails.ledgerId !== null && agentDetails.ledgerId !== getNameSpace.id) {
-          throw new BadRequestException(ResponseMessages.agent.error.networkMismatch);
-        }
       }
       const getApiKey = await this.getOrgAgentApiKey(orgId);
       const url = this.constructUrl(agentDetails);
 
       if (createDidPayload.method === DidMethod.POLYGON) {
+        createDidPayload.endpoint = agentDetails.agentEndPoint;
+      }
+
+      if (createDidPayload.method === DidMethod.ETHEREUM) {
         createDidPayload.endpoint = agentDetails.agentEndPoint;
       }
 
@@ -1055,6 +1056,32 @@ export class AgentServiceService {
     }
 
     return didDetails;
+  }
+
+  /**
+   * @returns Secp256k1 key pair for did:ethr
+   */
+  async createEthereumKeyPair(orgId: string): Promise<object> {
+    try {
+      const platformAdminSpinnedUp = await this.agentServiceRepository.platformAdminAgent(
+        CommonConstants.PLATFORM_ADMIN_ORG
+      );
+
+      const getPlatformAgentEndPoint = platformAdminSpinnedUp.org_agents[0].agentEndPoint;
+      const getDcryptedToken = await this.commonService.decryptPassword(platformAdminSpinnedUp?.org_agents[0].apiKey);
+
+      const url = `${getPlatformAgentEndPoint}${CommonConstants.CREATE_ETH_KEY}`;
+      this.logger.log(`Creating Ethereum key pair at URL: ${url}`);
+      const createKeyPairResponse = await this.commonService.httpPost(
+        url,
+        {},
+        { headers: { authorization: getDcryptedToken } }
+      );
+      return createKeyPairResponse;
+    } catch (error) {
+      this.logger.error(`error in createEthereumKeyPair : ${JSON.stringify(error)}`);
+      throw new RpcException(error.response ? error.response : error);
+    }
   }
 
   /**

--- a/apps/api-gateway/src/agent-service/agent-service.controller.ts
+++ b/apps/api-gateway/src/agent-service/agent-service.controller.ts
@@ -408,6 +408,32 @@ export class AgentController {
   }
 
   /**
+   * Create Secp256k1 key pair for did:ethr
+   * @param orgId The ID of the organization
+   * @param res The response object
+   * @returns Secp256k1 key pair for did:ethr
+   */
+  @Post('/orgs/:orgId/agents/ethereum/create-keys')
+  @ApiOperation({
+    summary: 'Create Secp256k1 key pair for did:ethr',
+    description: 'Create Secp256k1 key pair for did:ethr for an organization'
+  })
+  @UseGuards(AuthGuard('jwt'), OrgRolesGuard)
+  @Roles(OrgRoles.OWNER, OrgRoles.ADMIN, OrgRoles.PLATFORM_ADMIN, OrgRoles.ISSUER, OrgRoles.VERIFIER)
+  @ApiResponse({ status: HttpStatus.CREATED, description: 'Success', type: ApiResponseDto })
+  async createEthKeyPair(@Param('orgId') orgId: string, @Res() res: Response): Promise<Response> {
+    const didDetails = await this.agentService.createEthKeyPair(orgId);
+
+    const finalResponse: IResponse = {
+      statusCode: HttpStatus.CREATED,
+      message: ResponseMessages.agent.success.createKeys,
+      data: didDetails
+    };
+
+    return res.status(HttpStatus.CREATED).json(finalResponse);
+  }
+
+  /**
    * Configure the agent by organization
    * @param agentConfigureDto The details of the agent configuration
    * @param user The user making the request

--- a/apps/api-gateway/src/agent-service/agent-service.service.ts
+++ b/apps/api-gateway/src/agent-service/agent-service.service.ts
@@ -92,6 +92,13 @@ export class AgentService extends BaseService {
     return this.natsClient.sendNatsMessage(this.agentServiceProxy, 'polygon-create-keys', payload);
   }
 
+  async createEthKeyPair(orgId: string): Promise<object> {
+    const payload = { orgId };
+    // NATS call
+
+    return this.natsClient.sendNatsMessage(this.agentServiceProxy, 'ethereum-create-keys', payload);
+  }
+
   async agentConfigure(agentConfigureDto: AgentConfigureDto, user: user): Promise<object> {
     const payload = { agentConfigureDto, user };
     // NATS call

--- a/apps/api-gateway/src/dtos/migrate-schema.dto.ts
+++ b/apps/api-gateway/src/dtos/migrate-schema.dto.ts
@@ -1,0 +1,28 @@
+import { Equals, IsNotEmpty, IsString } from 'class-validator';
+
+import { ApiProperty } from '@nestjs/swagger';
+import { Transform } from 'class-transformer';
+import { trim } from '@credebl/common/cast.helper';
+import { JSONSchemaType } from '@credebl/enum/enum';
+
+export class MigrateW3CSchemaDto {
+  @ApiProperty({
+    description: 'The identifier of the schema',
+    example: '12345678-1234-5678-1234-567812345678'
+  })
+  @IsString()
+  @Transform(({ value }) => trim(value))
+  @IsNotEmpty({ message: 'schemaId is required' })
+  schemaId: string;
+
+  @ApiProperty({
+    description: 'The target schema type (only Ethereum supported)',
+    enum: [JSONSchemaType.ETHEREUM_W3C],
+    example: JSONSchemaType.ETHEREUM_W3C
+  })
+  @Equals(JSONSchemaType.ETHEREUM_W3C, {
+    message: 'Only Ethereum schema type is supported as target for now'
+  })
+  @IsNotEmpty({ message: 'targetSchemaType is required' })
+  targetSchemaType: JSONSchemaType;
+}

--- a/apps/api-gateway/src/schema/schema.controller.ts
+++ b/apps/api-gateway/src/schema/schema.controller.ts
@@ -46,6 +46,7 @@ import { CustomExceptionFilter } from 'apps/api-gateway/common/exception-handler
 import { CredDefSortFields, SortFields } from '@credebl/enum/enum';
 import { TrimStringParamPipe } from '@credebl/common/cast.helper';
 import { UpdateSchemaDto } from './dtos/update-schema-dto';
+import { MigrateW3CSchemaDto } from '../dtos/migrate-schema.dto';
 import { RequiresMarketplaceFeature } from '../marketplace/decorators/requires-marketplace-feature.decorator';
 import { MarketplaceEntitlementGuard } from '../marketplace/guards/marketplace-entitlement.guard';
 import { MarketplaceService } from '../marketplace/marketplace.service';
@@ -277,5 +278,42 @@ export class SchemaController {
       message: ResponseMessages.schema.success.update
     };
     return res.status(HttpStatus.OK).json(finalResponse);
+  }
+
+  /**
+   * Migrate the anchor of a schema to another ledger.
+   * @param migrateSchemaDetails The schema to migrate and its target schema type
+   * @param orgId The organization ID
+   * @returns The updated schema
+   */
+  @Post('/:orgId/migrate-schema')
+  @ApiOperation({
+    summary: 'Migrate anchor of schemas to another ledger.',
+    description: 'Enables the migration of schemas from current ledger to Ethereum network.'
+  })
+  @Roles(OrgRoles.OWNER, OrgRoles.ADMIN)
+  @UseGuards(AuthGuard('jwt'), OrgRolesGuard)
+  @ApiResponse({ status: HttpStatus.CREATED, description: 'Success', type: ApiResponseDto })
+  async migrateSchema(
+    @Res() res: Response,
+    @Body() migrateSchemaDetails: MigrateW3CSchemaDto,
+    @Param(
+      'orgId',
+      new ParseUUIDPipe({
+        exceptionFactory: (): Error => {
+          throw new BadRequestException(ResponseMessages.organisation.error.invalidOrgId);
+        }
+      })
+    )
+    orgId: string,
+    @User() user: IUserRequestInterface
+  ): Promise<Response> {
+    const schemaResponse = await this.appService.migrateSchema(migrateSchemaDetails, user, orgId);
+    const finalResponse: IResponse = {
+      statusCode: HttpStatus.CREATED,
+      message: ResponseMessages.schema.success.migrate,
+      data: schemaResponse
+    };
+    return res.status(HttpStatus.CREATED).json(finalResponse);
   }
 }

--- a/apps/api-gateway/src/schema/schema.service.ts
+++ b/apps/api-gateway/src/schema/schema.service.ts
@@ -9,6 +9,7 @@ import {
   ISchemasWithPagination
 } from '@credebl/common/interfaces/schema.interface';
 import { GetCredentialDefinitionBySchemaIdDto } from './dtos/get-all-schema.dto';
+import { MigrateW3CSchemaDto } from '../dtos/migrate-schema.dto';
 import { NATSClient } from '@credebl/common/NATSClient';
 
 import { UpdateSchemaResponse } from 'apps/ledger/src/schema/interfaces/schema.interface';
@@ -27,6 +28,15 @@ export class SchemaService extends BaseService {
   createSchema(schemaDetails: GenericSchemaDTO, user: IUserRequestInterface, orgId: string): Promise<ISchemaData> {
     const payload = { schemaDetails, user, orgId };
     return this.natsClient.sendNatsMessage(this.schemaServiceProxy, 'create-schema', payload);
+  }
+
+  migrateSchema(
+    migrateSchemaDetails: MigrateW3CSchemaDto,
+    user: IUserRequestInterface,
+    orgId: string
+  ): Promise<ISchemaData> {
+    const payload = { migrateSchemaDetails, user, orgId };
+    return this.natsClient.sendNatsMessage(this.schemaServiceProxy, 'migrate-w3c-schema', payload);
   }
 
   getSchemaById(schemaId: string, orgId: string): Promise<ISchemaInfo> {

--- a/apps/ledger/src/schema/interfaces/schema-payload.interface.ts
+++ b/apps/ledger/src/schema/interfaces/schema-payload.interface.ts
@@ -26,6 +26,7 @@ export interface IUpdateSchemaLedgerDetails {
     changedBy: string;
     publisherDid: string;
     ledgerId?: string;
+    type?: string;
 }
 
 export interface IAttributeValue {

--- a/apps/ledger/src/schema/interfaces/schema-payload.interface.ts
+++ b/apps/ledger/src/schema/interfaces/schema-payload.interface.ts
@@ -21,6 +21,13 @@ export interface ISchema {
     alias?: string;
 }
 
+export interface IUpdateSchemaLedgerDetails {
+    id: string;
+    changedBy: string;
+    publisherDid: string;
+    ledgerId?: string;
+}
+
 export interface IAttributeValue {
     isRequired: boolean;    
     attributeName: string;
@@ -113,7 +120,13 @@ export interface W3CCreateSchema {
     url: string,
     orgId: string,
     schemaRequestPayload: object
-}  
+}
+
+export interface W3CMigrateSchema {
+    url: string,
+    orgId: string,
+    schemaRequestPayload: object
+}
 
 export interface IdAttribute extends W3CSchemaAttributes {
     format: string;

--- a/apps/ledger/src/schema/interfaces/schema.interface.ts
+++ b/apps/ledger/src/schema/interfaces/schema.interface.ts
@@ -105,6 +105,17 @@ export interface IschemaPayload {
   user: IUserRequestInterface;
   orgId: string;
 }
+
+export interface IMigrateW3CSchema {
+  schemaId: string;
+  targetSchemaType: JSONSchemaType.ETHEREUM_W3C;
+}
+
+export interface IMigrateW3CSchemaPayload {
+  migrateSchemaDetails: IMigrateW3CSchema;
+  user: IUserRequestInterface;
+  orgId: string;
+}
 export interface ISchemasResult {
   id: string;
   createDateTime: Date;

--- a/apps/ledger/src/schema/repositories/schema.repository.ts
+++ b/apps/ledger/src/schema/repositories/schema.repository.ts
@@ -465,7 +465,8 @@ export class SchemaRepository {
           ledgerId: updateSchema.ledgerId,
           publisherDid: updateSchema.publisherDid,
           issuerId: updateSchema.publisherDid,
-          lastChangedBy: updateSchema.changedBy
+          lastChangedBy: updateSchema.changedBy,
+          type: updateSchema.type
         }
       });
       return updateResult;

--- a/apps/ledger/src/schema/repositories/schema.repository.ts
+++ b/apps/ledger/src/schema/repositories/schema.repository.ts
@@ -2,7 +2,13 @@ import { AgentDetails, ISchemasWithCount, IUpdateSchema, UpdateSchemaResponse } 
 /* eslint-disable camelcase */
 import { ConflictException, Injectable, InternalServerErrorException, Logger } from '@nestjs/common';
 import { ICredDefWithCount, IPlatformSchemasWithOrg } from '@credebl/common/interfaces/schema.interface';
-import { ISaveSchema, ISchema, ISchemaExist, ISchemaSearchCriteria } from '../interfaces/schema-payload.interface';
+import {
+  ISaveSchema,
+  ISchema,
+  ISchemaExist,
+  ISchemaSearchCriteria,
+  IUpdateSchemaLedgerDetails
+} from '../interfaces/schema-payload.interface';
 import { Prisma, ledgers, org_agents, org_agents_type, organisation, schema } from '@prisma/client';
 import { SchemaType, SortValue } from '@credebl/enum/enum';
 
@@ -431,6 +437,40 @@ export class SchemaRepository {
       });
     } catch (error) {
       this.logger.error(`Error in getting get schema by schema ledger id: ${error}`);
+      throw error;
+    }
+  }
+
+  async getSchemaByOrgSchemaUrl(schemaUrl: string, orgId: string): Promise<schema> {
+    try {
+      return this.prisma.schema.findFirst({
+        where: {
+          orgId,
+          schemaLedgerId: schemaUrl
+        }
+      });
+    } catch (error) {
+      this.logger.error(`Error in getting get schema by org id and ledger id: ${error}`);
+      throw error;
+    }
+  }
+
+  async updateSchemaLedgerDetails(updateSchema: IUpdateSchemaLedgerDetails): Promise<schema> {
+    try {
+      const updateResult = await this.prisma.schema.update({
+        where: {
+          id: updateSchema.id
+        },
+        data: {
+          ledgerId: updateSchema.ledgerId,
+          publisherDid: updateSchema.publisherDid,
+          issuerId: updateSchema.publisherDid,
+          lastChangedBy: updateSchema.changedBy
+        }
+      });
+      return updateResult;
+    } catch (error) {
+      this.logger.error(`Error in updating schema repository: ${error.message} `);
       throw error;
     }
   }

--- a/apps/ledger/src/schema/schema.controller.ts
+++ b/apps/ledger/src/schema/schema.controller.ts
@@ -15,7 +15,7 @@ import {
   ISchemaDetails,
   ISchemasWithPagination
 } from '@credebl/common/interfaces/schema.interface';
-import { IschemaPayload } from './interfaces/schema.interface';
+import { IMigrateW3CSchemaPayload, IschemaPayload } from './interfaces/schema.interface';
 import { ISchemaId } from './schema.interface';
 import { UpdateSchemaDto } from 'apps/api-gateway/src/schema/dtos/update-schema-dto';
 
@@ -28,6 +28,12 @@ export class SchemaController {
   async createSchema(payload: IschemaPayload): Promise<ISchemaData> {
     const { schemaDetails, user, orgId } = payload;
     return this.schemaService.createSchema(schemaDetails, user, orgId);
+  }
+
+  @MessagePattern({ cmd: 'migrate-w3c-schema' })
+  async migrateW3cSchema(payload: IMigrateW3CSchemaPayload): Promise<ISchemaData> {
+    const { migrateSchemaDetails, user, orgId } = payload;
+    return this.schemaService.migrateW3CSchema(migrateSchemaDetails, user, orgId);
   }
 
   @MessagePattern({ cmd: 'get-schemas-details' })

--- a/apps/ledger/src/schema/schema.service.ts
+++ b/apps/ledger/src/schema/schema.service.ts
@@ -432,7 +432,8 @@ export class SchemaService extends BaseService {
       const updateSchemaDetails: IUpdateSchemaLedgerDetails = {
         id: schema.id,
         publisherDid: agentDetails.orgDid,
-        changedBy: user.id
+        changedBy: user.id,
+        type: targetSchemaType
       };
       const updateW3CSchema = await this.updateW3CSchemas(updateSchemaDetails);
 

--- a/apps/ledger/src/schema/schema.service.ts
+++ b/apps/ledger/src/schema/schema.service.ts
@@ -564,13 +564,22 @@ export class SchemaService extends BaseService {
       .toPromise()
       .catch((error) => {
         this.logger.error(`Error in migrating W3C schema : ${JSON.stringify(error)}`);
+        // agent-controller's migrate-schema endpoint returns errors as { reason } (400) or
+        // { message } (500), a different shape than _createW3CSchema's sibling call assumes -
+        // guard every level so an unexpected shape surfaces a real message instead of throwing
+        // on the nested read itself.
         throw new HttpException(
           {
-            status: error.error.code,
-            error: error.message,
-            message: error.error.message.error.message
+            status: error?.error?.code,
+            error: error?.message,
+            message:
+              error?.error?.message?.error?.message ??
+              error?.error?.reason ??
+              error?.error?.message ??
+              error?.message ??
+              'Failed to migrate W3C schema'
           },
-          error.error
+          error?.error
         );
       });
     return W3CSchemaResponse;

--- a/apps/ledger/src/schema/schema.service.ts
+++ b/apps/ledger/src/schema/schema.service.ts
@@ -307,7 +307,11 @@ export class SchemaService extends BaseService {
         });
       }
 
-      const url = `${agentEndPoint}${CommonConstants.CREATE_POLYGON_W3C_SCHEMA}`;
+      const url = `${agentEndPoint}${
+        schemaPayload.schemaType === JSONSchemaType.ETHEREUM_W3C
+          ? CommonConstants.CREATE_ETHEREUM_W3C_SCHEMA
+          : CommonConstants.CREATE_POLYGON_W3C_SCHEMA
+      }`;
 
       let schemaObject;
       let schemaResourceId: string | undefined;
@@ -318,7 +322,7 @@ export class SchemaService extends BaseService {
         const schemaUrl = `${process.env.SCHEMA_FILE_SERVER_URL}${schemaResourceId}`;
         schemaObject = w3cSchemaBuilder(attributes, schemaName, description, schemaUrl);
       } else {
-        // POLYGON_W3C: URL is assigned by the agent after upload; $id cannot be set in advance
+        // POLYGON_W3C / ETHEREUM_W3C: URL is assigned by the agent after upload; $id cannot be set in advance
         schemaObject = w3cSchemaBuilder(attributes, schemaName, description);
       }
 
@@ -338,10 +342,13 @@ export class SchemaService extends BaseService {
         orgId,
         schemaRequestPayload: agentSchemaPayload
       };
-      if (schemaPayload.schemaType === JSONSchemaType.POLYGON_W3C) {
+      if (
+        schemaPayload.schemaType === JSONSchemaType.POLYGON_W3C ||
+        schemaPayload.schemaType === JSONSchemaType.ETHEREUM_W3C
+      ) {
         const createSchemaPayload = await this._createW3CSchema(W3cSchemaPayload);
         createSchema = createSchemaPayload.response;
-        createSchema.type = JSONSchemaType.POLYGON_W3C;
+        createSchema.type = schemaPayload.schemaType;
       } else {
         const createSchemaPayload = await this._createW3CledgerAgnostic(schemaObject, schemaResourceId);
         if (!createSchemaPayload) {

--- a/apps/ledger/src/schema/schema.service.ts
+++ b/apps/ledger/src/schema/schema.service.ts
@@ -19,13 +19,16 @@ import {
   ISchemaCredDeffSearchInterface,
   ISchemaExist,
   ISchemaSearchCriteria,
-  W3CCreateSchema
+  IUpdateSchemaLedgerDetails,
+  W3CCreateSchema,
+  W3CMigrateSchema
 } from './interfaces/schema-payload.interface';
 import { ResponseMessages } from '@credebl/common/response-messages';
 import {
   ICreateSchema,
   ICreateW3CSchema,
   IGenericSchema,
+  IMigrateW3CSchema,
   IUpdateSchema,
   IUserRequestInterface,
   UpdateSchemaResponse
@@ -379,6 +382,74 @@ export class SchemaService extends BaseService {
     }
   }
 
+  async migrateW3CSchema(
+    schemaPayload: IMigrateW3CSchema,
+    user: IUserRequestInterface,
+    orgId: string
+  ): Promise<schema> {
+    try {
+      const { schemaId, targetSchemaType } = schemaPayload;
+      const agentDetails = await this.schemaRepository.getAgentDetailsByOrgId(orgId);
+      if (!agentDetails) {
+        throw new NotFoundException(ResponseMessages.schema.error.agentDetailsNotFound, {
+          cause: new Error(),
+          description: ResponseMessages.errorMessages.notFound
+        });
+      }
+      const schemaUrl = `${process.env.SCHEMA_FILE_SERVER_URL}${schemaId}`;
+      const schema = await this.schemaRepository.getSchemaByOrgSchemaUrl(schemaUrl, orgId);
+      if (!schema) {
+        throw new NotFoundException(ResponseMessages.schema.error.notFound, {
+          cause: new Error(),
+          description: ResponseMessages.errorMessages.notFound
+        });
+      }
+
+      const { agentEndPoint } = agentDetails;
+
+      const ledgerAndNetworkDetails = await checkDidLedgerAndNetwork(targetSchemaType, agentDetails.orgDid);
+      if (!ledgerAndNetworkDetails) {
+        throw new BadRequestException(ResponseMessages.schema.error.orgDidAndSchemaType, {
+          cause: new Error(),
+          description: ResponseMessages.errorMessages.badRequest
+        });
+      }
+
+      const url = `${agentEndPoint}${CommonConstants.MIGRATE_ETHEREUM_W3C_SCHEMA}`;
+
+      const agentSchemaPayload = {
+        did: agentDetails.orgDid,
+        schemaId
+      };
+      const W3cSchemaPayload: W3CMigrateSchema = {
+        url,
+        orgId,
+        schemaRequestPayload: agentSchemaPayload
+      };
+
+      await this._migrateW3CSchema(W3cSchemaPayload);
+
+      const updateSchemaDetails: IUpdateSchemaLedgerDetails = {
+        id: schema.id,
+        publisherDid: agentDetails.orgDid,
+        changedBy: user.id
+      };
+      const updateW3CSchema = await this.updateW3CSchemas(updateSchemaDetails);
+
+      if (!updateW3CSchema) {
+        throw new BadRequestException(ResponseMessages.schema.error.updateW3CSchema, {
+          cause: new Error(),
+          description: ResponseMessages.errorMessages.serverError
+        });
+      }
+
+      return updateW3CSchema;
+    } catch (error) {
+      this.logger.error(`[migrateW3CSchema] - outer Error: ${JSON.stringify(error)}`);
+      throw error;
+    }
+  }
+
   private async storeW3CSchemas(schemaDetails, user, orgId, attributes, alias, schemaVersion: string): Promise<schema> {
     let ledgerDetails;
     const schemaServerUrl = `${process.env.SCHEMA_FILE_SERVER_URL}${schemaDetails.schemaId}`;
@@ -476,6 +547,50 @@ export class SchemaService extends BaseService {
         );
       });
     return W3CSchemaResponse;
+  }
+
+  async _migrateW3CSchema(payload: W3CMigrateSchema): Promise<{
+    response: string;
+  }> {
+    const natsPattern = {
+      cmd: 'agent-migrate-w3c-schema'
+    };
+    const W3CSchemaResponse = await from(this.natsClient.send<string>(this.schemaServiceProxy, natsPattern, payload))
+      .pipe(
+        map((response) => ({
+          response
+        }))
+      )
+      .toPromise()
+      .catch((error) => {
+        this.logger.error(`Error in migrating W3C schema : ${JSON.stringify(error)}`);
+        throw new HttpException(
+          {
+            status: error.error.code,
+            error: error.message,
+            message: error.error.message.error.message
+          },
+          error.error
+        );
+      });
+    return W3CSchemaResponse;
+  }
+
+  private async updateW3CSchemas(updateSchema: IUpdateSchemaLedgerDetails): Promise<schema> {
+    const ledgerNameSpace = networkNamespace(updateSchema.publisherDid);
+    const ledgerDetails = await this.schemaRepository.getLedgerByNamespace(ledgerNameSpace);
+
+    if (!ledgerDetails) {
+      throw new NotFoundException(ResponseMessages.schema.error.networkNotFound, {
+        cause: new Error(),
+        description: ResponseMessages.errorMessages.notFound
+      });
+    }
+    const updateSchemaDetails: IUpdateSchemaLedgerDetails = {
+      ...updateSchema,
+      ledgerId: ledgerDetails.id
+    };
+    return this.schemaRepository.updateSchemaLedgerDetails(updateSchemaDetails);
   }
 
   // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/explicit-function-return-type

--- a/libs/common/src/cast.helper.ts
+++ b/libs/common/src/cast.helper.ts
@@ -416,6 +416,10 @@ export function checkDidLedgerAndNetwork(schemaType: string, did: string): boole
     return cleanDid.includes(JSONSchemaType.POLYGON_W3C);
   }
 
+  if (JSONSchemaType.ETHEREUM_W3C === cleanSchemaType) {
+    return cleanDid.includes(JSONSchemaType.ETHEREUM_W3C);
+  }
+
   if (JSONSchemaType.LEDGER_LESS === cleanSchemaType) {
     return cleanDid.startsWith(ledgerLessDIDType.DID_KEY) || cleanDid.startsWith(ledgerLessDIDType.DID_WEB);
   }

--- a/libs/common/src/common.constant.ts
+++ b/libs/common/src/common.constant.ts
@@ -92,6 +92,9 @@ export enum CommonConstants {
   // POLYGON BASED W3C SCHEMAS
   CREATE_POLYGON_W3C_SCHEMA = '/polygon/create-schema',
 
+  // ETHEREUM BASED W3C SCHEMAS
+  CREATE_ETHEREUM_W3C_SCHEMA = '/ethereum/create-schema',
+
   // SHARED AGENT
   URL_SHAGENT_CREATE_TENANT = '/multi-tenancy/create-tenant',
   URL_SHAGENT_DELETE_SUB_WALLET = '/multi-tenancy/#',
@@ -117,6 +120,7 @@ export enum CommonConstants {
 
   // CREATE KEYS
   CREATE_POLYGON_SECP256k1_KEY = '/polygon/create-keys',
+  CREATE_ETH_KEY = '/ethereum/create-keys',
 
   // OID4VC URLs
   URL_OIDC_ISSUER_CREATE = '/openid4vc/issuer',
@@ -163,6 +167,9 @@ export enum CommonConstants {
 
   // POLYGON KEYWORDS
   POLYGON = 'polygon',
+
+  // ETHEREUM KEYWORDS
+  ETHR = 'ethr',
 
   // DOMAIN EVENTS
   DOMAIN_EVENT_SCHEMA_CREATED = 'Schema Created',

--- a/libs/common/src/common.constant.ts
+++ b/libs/common/src/common.constant.ts
@@ -94,6 +94,7 @@ export enum CommonConstants {
 
   // ETHEREUM BASED W3C SCHEMAS
   CREATE_ETHEREUM_W3C_SCHEMA = '/ethereum/create-schema',
+  MIGRATE_ETHEREUM_W3C_SCHEMA = '/ethereum/migrate-schema',
 
   // SHARED AGENT
   URL_SHAGENT_CREATE_TENANT = '/multi-tenancy/create-tenant',

--- a/libs/common/src/common.constant.ts
+++ b/libs/common/src/common.constant.ts
@@ -337,6 +337,7 @@ export enum CommonConstants {
   BUILDERNET = 'buildernet',
   MAINNET = 'mainnet',
   LIVENET = 'livenet',
+  SEPOLIA = 'sepolia',
 
   // Features Id
   // eslint-disable-next-line @typescript-eslint/no-duplicate-enum-values

--- a/libs/common/src/common.utils.spec.ts
+++ b/libs/common/src/common.utils.spec.ts
@@ -1,0 +1,23 @@
+import { networkNamespace } from './common.utils';
+
+describe('networkNamespace', () => {
+  it('resolves a did:ethr sepolia DID to the sepolia namespace, not mainnet', () => {
+    expect(networkNamespace('did:ethr:sepolia:0xabc')).toBe('ethr:sepolia');
+  });
+
+  it('resolves a did:ethr mainnet DID to the mainnet namespace', () => {
+    expect(networkNamespace('did:ethr:mainnet:0xabc')).toBe('ethr:mainnet');
+  });
+
+  it('resolves a did:polygon testnet DID to the testnet namespace', () => {
+    expect(networkNamespace('did:polygon:testnet:0xabc')).toBe('polygon:testnet');
+  });
+
+  it('resolves a did:polygon mainnet DID to the mainnet namespace', () => {
+    expect(networkNamespace('did:polygon:mainnet:0xabc')).toBe('polygon:mainnet');
+  });
+
+  it('passes through the namespace segment unchanged for other DID methods', () => {
+    expect(networkNamespace('did:indy:bcovrin:testnet:abc123')).toBe('indy');
+  });
+});

--- a/libs/common/src/common.utils.ts
+++ b/libs/common/src/common.utils.ts
@@ -59,8 +59,9 @@ export const networkNamespace = (did: string): string => {
   // Split the DID into segments using the colon as a delimiter
   const segments = did.split(':');
   const hasPolygon = segments.some((segment) => segment.includes(CommonConstants.POLYGON));
+  const hasEthereum = segments.some((segment) => segment.includes(CommonConstants.ETHR));
   const hasTestnet = segments.some((segment) => segment.includes(CommonConstants.TESTNET));
-  if (hasPolygon) {
+  if (hasPolygon || hasEthereum) {
     return hasTestnet ? `${segments[1]}:${segments[2]}` : `${segments[1]}:${CommonConstants.MAINNET}`;
   }
 

--- a/libs/common/src/common.utils.ts
+++ b/libs/common/src/common.utils.ts
@@ -60,7 +60,9 @@ export const networkNamespace = (did: string): string => {
   const segments = did.split(':');
   const hasPolygon = segments.some((segment) => segment.includes(CommonConstants.POLYGON));
   const hasEthereum = segments.some((segment) => segment.includes(CommonConstants.ETHR));
-  const hasTestnet = segments.some((segment) => segment.includes(CommonConstants.TESTNET));
+  const hasTestnet = segments.some(
+    (segment) => segment.includes(CommonConstants.TESTNET) || segment.includes(CommonConstants.SEPOLIA)
+  );
   if (hasPolygon || hasEthereum) {
     return hasTestnet ? `${segments[1]}:${segments[2]}` : `${segments[1]}:${CommonConstants.MAINNET}`;
   }

--- a/libs/common/src/response-messages/index.ts
+++ b/libs/common/src/response-messages/index.ts
@@ -309,7 +309,8 @@ export const ResponseMessages = {
     success: {
       fetch: 'Schema retrieved successfully.',
       create: 'Schema created successfully.',
-      update: 'Schema updated successfully'
+      update: 'Schema updated successfully',
+      migrate: 'Schema migrated successfully.'
     },
     error: {
       invalidSchemaId: 'Please provide valid schema Id',
@@ -335,7 +336,8 @@ export const ResponseMessages = {
       W3CSchemaNotFOund: 'Error while resolving W3C schema',
       storeW3CSchema: 'Error while storing W3C schema',
       networkNotFound: 'Error while fetching network',
-      orgDidAndSchemaType: 'Organization DID and schema type does not match'
+      orgDidAndSchemaType: 'Organization DID and schema type does not match',
+      updateW3CSchema: 'Error while updating W3C schema'
     }
   },
   credentialDefinition: {

--- a/libs/enum/src/enum.ts
+++ b/libs/enum/src/enum.ts
@@ -53,7 +53,8 @@ export enum DidMethod {
   INDY = 'indy',
   KEY = 'key',
   WEB = 'web',
-  POLYGON = 'polygon'
+  POLYGON = 'polygon',
+  ETHEREUM = 'ethr'
 }
 
 export enum Ledgers {
@@ -274,6 +275,7 @@ export enum IndySchemaDataType {
 
 export enum JSONSchemaType {
   POLYGON_W3C = 'polygon',
+  ETHEREUM_W3C = 'ethr',
   LEDGER_LESS = 'no_ledger'
 }
 

--- a/libs/prisma-service/prisma/data/credebl-master-table/credebl-master-table.json
+++ b/libs/prisma-service/prisma/data/credebl-master-table/credebl-master-table.json
@@ -129,6 +129,24 @@
       "indyNamespace": "polygon:mainnet"
     },
     {
+      "name": "Ethr Sepolia",
+      "networkType": "sepolia",
+      "poolConfig": "",
+      "isActive": true,
+      "networkString": "sepolia",
+      "nymTxnEndpoint": "",
+      "indyNamespace": "ethr:sepolia"
+    },
+    {
+      "name": "Ethr Mainnet",
+      "networkType": "mainnet",
+      "poolConfig": "",
+      "isActive": true,
+      "networkString": "mainnet",
+      "nymTxnEndpoint": "",
+      "indyNamespace": "ethr:mainnet"
+    },
+    {
       "name": "NA",
       "networkType": "NA",
       "poolConfig": "NA",
@@ -156,6 +174,15 @@
         "did:polygon": {
             "mainnet":"did:polygon:mainnet",
             "testnet":"did:polygon:testnet"
+        }
+    }
+    },
+    {
+      "name": "ethereum",
+      "details":  {
+        "did:ethr": {
+            "mainnet":"did:ethr:mainnet",
+            "testnet":"did:ethr:sepolia"
         }
     }
     },

--- a/libs/prisma-service/prisma/migrations/20260731000000_add_ethr_ledger_rows/migration.sql
+++ b/libs/prisma-service/prisma/migrations/20260731000000_add_ethr_ledger_rows/migration.sql
@@ -1,0 +1,17 @@
+-- Non-destructive insert of the did:ethr ledger rows. seed.ts is not run against production (it
+-- deleteMany()+recreates the ledgers/ledgerConfig tables, which would break org_agents.ledgerId and
+-- schema foreign keys), so rows that only exist in the seed JSON never reach prod. Guarded with
+-- WHERE NOT EXISTS since neither table has a unique constraint on the columns being checked, making
+-- this safe to run even if a prior seed run already created these rows in a lower environment.
+
+INSERT INTO "ledgers" ("id", "name", "networkType", "poolConfig", "isActive", "networkString", "nymTxnEndpoint", "indyNamespace")
+SELECT gen_random_uuid(), 'Ethr Sepolia', 'sepolia', '', true, 'sepolia', '', 'ethr:sepolia'
+WHERE NOT EXISTS (SELECT 1 FROM "ledgers" WHERE "indyNamespace" = 'ethr:sepolia');
+
+INSERT INTO "ledgers" ("id", "name", "networkType", "poolConfig", "isActive", "networkString", "nymTxnEndpoint", "indyNamespace")
+SELECT gen_random_uuid(), 'Ethr Mainnet', 'mainnet', '', true, 'mainnet', '', 'ethr:mainnet'
+WHERE NOT EXISTS (SELECT 1 FROM "ledgers" WHERE "indyNamespace" = 'ethr:mainnet');
+
+INSERT INTO "ledgerConfig" ("id", "name", "details")
+SELECT gen_random_uuid(), 'ethereum', '{"did:ethr":{"mainnet":"did:ethr:mainnet","testnet":"did:ethr:sepolia"}}'::jsonb
+WHERE NOT EXISTS (SELECT 1 FROM "ledgerConfig" WHERE "name" = 'ethereum');


### PR DESCRIPTION
## Summary
Adds `POST /orgs/:orgId/migrate-schema` to re-anchor a W3C schema onto did:ethr, following the existing `createW3CSchema` flow's structure:

- New `MigrateW3CSchemaDto` (api-gateway), route + NATS proxy, ledger app `migrateW3CSchema()`/`updateW3CSchemas()`/`_migrateW3CSchema()`, agent-service `migrateW3CSchema()` HTTP call-out and its NATS handler.
- #53's interface-casing fix (`IMigrateW3CSchemaPayload`, not `IMigrateW3cSchemaPayload`) and #54's `publisherDid` field / single-typed-param signature are applied directly rather than reproducing the two-step historical fix.
- Renamed the new update-payload interface/repository method to `IUpdateSchemaLedgerDetails`/`updateSchemaLedgerDetails` (source PR named both `IUpdateSchema`/`updateSchema`) — current `develop` already has an unrelated `IUpdateSchema` interface and `schemaRepository.updateSchema()` (bulk alias/schemaLedgerId update), so reusing those names would have collided with a different, already-shipped feature.
- Adapted the migrate-schema URL construction to the current simplified, single-constant pattern (`CommonConstants.MIGRATE_ETHEREUM_W3C_SCHEMA`) instead of the source PR's `DEDICATED_`/`SHARED_` split: confirmed agent-controller's actual live endpoint (`src/controllers/ethereum/EthereumController.ts`, `POST /ethereum/migrate-schema`, from the already-ported #34) is a single flat route with no per-tenant variant, and `createW3CSchema`'s sibling flow on current `develop` was already simplified the same way — the old dedicated/shared distinction no longer exists in this codebase for W3C schema creation, so migrate-schema shouldn't invent it back.

No new Prisma migration needed — `publisherDid`/`issuerId`/`ledgerId`/`lastChangedBy` all already exist as columns on the `schema` model.

## Depends on
#feat/eth/did-ethr-foundation (this branch is stacked on it — needs `JSONSchemaType.ETHEREUM_W3C` etc. from that PR first)

## Verification
- `nest build ledger`, `nest build api-gateway`, `nest build agent-service`: all clean.
- Lint: no new errors introduced.
- Existing specs touching nearby code (`agent-service.service.spec.ts`) pass 5/5; unrelated pre-existing test-file breakage confirmed untouched by this change.