### PR TITLE
fix(marketplace): grant full entitlements when marketplace is disabled

### DIFF
--- a/apps/api-gateway/src/marketplace/marketplace.controller.ts
+++ b/apps/api-gateway/src/marketplace/marketplace.controller.ts
@@ -124,7 +124,12 @@ export class MarketplaceController {
   @UseGuards(AuthGuard('jwt'))
   @ApiBearerAuth()
   async getEntitlements(@Param('orgId') orgId: string, @User() reqUser: user, @Res() res: Response): Promise<Response> {
-    if (isPlatformAdmin(reqUser)) {
+    // Grant full entitlements without contacting the marketplace microservice for platform admins,
+    // and whenever marketplace billing is disabled (MARKETPLACE_ENABLED !== 'true'). This mirrors the
+    // MarketplaceEntitlementGuard's own short-circuit so core SSI flows (schema/issuance/verification)
+    // are never gated on the availability of the marketplace service when the feature is off.
+    const marketplaceDisabled = 'true' !== `${process.env.MARKETPLACE_ENABLED}`.toLowerCase();
+    if (isPlatformAdmin(reqUser) || marketplaceDisabled) {
       const data = { orgId, ...PLATFORM_ADMIN_ENTITLEMENTS };
       const finalResponse: IResponse = { statusCode: HttpStatus.OK, message: 'Success', data };
       return res.status(HttpStatus.OK).json(finalResponse);


### PR DESCRIPTION
## Problem (confirmed on DEV)
With `MARKETPLACE_ENABLED=false` and `MARKETPLACE_REQUIRED=false` (marketplace microservice not deployed), studio still showed **"Subscription required"** on schema-create / issuance / verification pages, and api-gateway logged:
```
ERROR [CommonService] Empty response. There are no subscribers listening to that message ("{"cmd":"marketplace-get-entitlements"}")
```

## Root cause
The `MARKETPLACE_ENABLED` flag was only wired into `MarketplaceEntitlementGuard` (which short-circuits when disabled). But the **REST endpoint** `GET /marketplace/orgs/:orgId/entitlements` called `marketplaceService.getEntitlements()` **unconditionally**, emitting the NATS `marketplace-get-entitlements` regardless of the flag. Studio's `EntitlementGate` is **fail-closed** — on a failed entitlements fetch it sets `error` / `isAllowed=false` and renders "Subscription required" instead of the form. Since the marketplace service isn't deployed, that fetch always failed → the gate always blocked, and the NATS no-subscriber error was logged on every page load.

## Fix
Short-circuit the endpoint the same way the guard does: when `MARKETPLACE_ENABLED !== 'true'` (or the caller is a platform admin), return full entitlements (`PLATFORM_ADMIN_ENTITLEMENTS` — all features `true`, empty limits/usage) **without** the NATS call. Studio's gate then sees `isAllowed = true` and renders the form; no NATS emit → no error.

- 6-line change in `apps/api-gateway/src/marketplace/marketplace.controller.ts`.
- No behavior change when marketplace **is** enabled (still calls the service and enforces entitlements).

## Verify
- With `MARKETPLACE_ENABLED=false`: studio schema/issuance/verification pages render (no "Subscription required"); no `marketplace-get-entitlements` no-subscriber errors in api-gateway logs.
- With `MARKETPLACE_ENABLED=true` + marketplace service up: entitlements enforced as before.

## Note
This addresses the schema/issuance/verification blocker (the `entitlements` endpoint). The `usage-summary` / `metering-events` endpoints on the **billing** page are separate and still call the service; not touched here since they don't gate core SSI flows. Separate from Phase A — this is a fix to the phenix-id marketplace feature.
