### PR TITLE
fix(marketplace): gate usage metering behind marketplace flags

### DIFF
--- a/apps/api-gateway/src/issuance/issuance.controller.ts
+++ b/apps/api-gateway/src/issuance/issuance.controller.ts
@@ -86,6 +86,7 @@ import { IWebhookUrlInfo } from '@credebl/common/interfaces/webhook.interface';
 import { RequiresMarketplaceFeature } from '../marketplace/decorators/requires-marketplace-feature.decorator';
 import { MarketplaceEntitlementGuard } from '../marketplace/guards/marketplace-entitlement.guard';
 import { MarketplaceService } from '../marketplace/marketplace.service';
+import { isMarketplaceMeteringEnabled } from '../marketplace/utils/marketplace-config.util';
 @Controller()
 @UseFilters(CustomExceptionFilter)
 @ApiTags('credentials')
@@ -980,7 +981,12 @@ export class IssuanceController {
     // shared/cloud agents the microservice resolves it via tenant lookup and returns it here.
     const resolvedOrgId = (getCredentialDetails as { response?: { orgId?: string } } | undefined)?.response?.orgId;
     const issuanceSourceId = issueCredentialDto.id || issueCredentialDto.threadId;
-    if (resolvedOrgId && issuanceSourceId && this.isIssuedCredentialState(issueCredentialDto.state)) {
+    if (
+      isMarketplaceMeteringEnabled() &&
+      resolvedOrgId &&
+      issuanceSourceId &&
+      this.isIssuedCredentialState(issueCredentialDto.state)
+    ) {
       void this.marketplaceService
         .recordUsageEvent({
           orgId: resolvedOrgId,

--- a/apps/api-gateway/src/marketplace/utils/marketplace-config.util.ts
+++ b/apps/api-gateway/src/marketplace/utils/marketplace-config.util.ts
@@ -1,0 +1,16 @@
+/**
+ * Single source of truth for the marketplace feature flags, so call sites don't re-implement
+ * `process.env.*` string checks inline (which is how MARKETPLACE_METERING_ENABLED ended up defined
+ * but never honored). Both flags default to OFF unless explicitly set to the string 'true'.
+ */
+const isFlagEnabled = (value: string | undefined): boolean => 'true' === `${value}`.toLowerCase();
+
+/** Master switch for the whole marketplace/billing feature. */
+export const isMarketplaceEnabled = (): boolean => isFlagEnabled(process.env.MARKETPLACE_ENABLED);
+
+/**
+ * Usage metering is a sub-feature of the marketplace: it only runs when the marketplace is enabled
+ * AND metering is explicitly enabled. When either is off, issuance/verification must not attempt to
+ * record usage (no marketplace microservice to receive it → noisy warnings for nothing).
+ */
+export const isMarketplaceMeteringEnabled = (): boolean => isMarketplaceEnabled() && isFlagEnabled(process.env.MARKETPLACE_METERING_ENABLED);

--- a/apps/api-gateway/src/verification/verification.controller.ts
+++ b/apps/api-gateway/src/verification/verification.controller.ts
@@ -56,6 +56,7 @@ import { IWebhookUrlInfo } from '@credebl/common/interfaces/webhook.interface';
 import { RequiresMarketplaceFeature } from '../marketplace/decorators/requires-marketplace-feature.decorator';
 import { MarketplaceEntitlementGuard } from '../marketplace/guards/marketplace-entitlement.guard';
 import { MarketplaceService } from '../marketplace/marketplace.service';
+import { isMarketplaceMeteringEnabled } from '../marketplace/utils/marketplace-config.util';
 
 @UseFilters(CustomExceptionFilter)
 @Controller()
@@ -475,6 +476,7 @@ export class VerificationController {
     const resolvedOrgId = (webhookProofPresentation as { orgId?: string } | undefined)?.orgId;
     const verificationSourceId = proofPresentationPayload.presentationId || proofPresentationPayload.threadId;
     if (
+      isMarketplaceMeteringEnabled() &&
       resolvedOrgId &&
       verificationSourceId &&
       (proofPresentationPayload.isVerified ||


### PR DESCRIPTION
## Problem
With the marketplace disabled and its microservice not deployed, `api-gateway` logged a warning on **every** completed issuance/verification:
```
error in recording marketplace issuance usage ::: {}
error in recording marketplace verification usage ::: {}
```
`issuance.controller.ts` and `verification.controller.ts` call `marketplaceService.recordUsageEvent(...)` on completion, but the guard conditions checked only `orgId`/`sourceId`/`state` — **no marketplace flag**. So it fired regardless, hit the absent marketplace service over NATS (no subscriber), and the fire-and-forget `.catch` logged the warning. The dedicated `MARKETPLACE_METERING_ENABLED` env existed but was **never read** (same half-wired pattern that `MARKETPLACE_ENABLED` had before #69).

It was harmless (fire-and-forget, never blocked issuance/verification) but noisy and confusing.

## Fix
Add a single-source-of-truth helper and finally wire the metering flag:

- `apps/api-gateway/src/marketplace/utils/marketplace-config.util.ts`
  - `isMarketplaceEnabled()` — master switch (`MARKETPLACE_ENABLED === 'true'`)
  - `isMarketplaceMeteringEnabled()` — `isMarketplaceEnabled() && MARKETPLACE_METERING_ENABLED === 'true'` (metering is a sub-feature; runs only when both are on)
- Gate both `recordUsageEvent` call sites on `isMarketplaceMeteringEnabled()` (placed first, so it short-circuits).

Result: when the marketplace (or metering specifically) is off, no NATS call and no warning; when both are on, behavior is unchanged.

## Scope / notes
- 3 files, +25/-1. No behavior change when metering is enabled.
- Left the two enforcement guards' and #69 controller's existing inline `MARKETPLACE_ENABLED` checks untouched to keep the diff focused; they can adopt `isMarketplaceEnabled()` later for full DRY.
- api-gateway only — needs an api-gateway redeploy to take effect (the flags are read at runtime here, not at decorator-load).

## Verify
- With `MARKETPLACE_ENABLED`/`MARKETPLACE_METERING_ENABLED` unset or `false`: issue/verify a credential → no `error in recording marketplace … usage` warnings; issuance/verification still complete normally.
- With both `= true` and the marketplace service running: usage is recorded as before.
