### PR TITLE
fix: update agent-provisioning readiness check

### DIFF
--- a/apps/agent-provisioning/AFJ/scripts/docker_start_agent.sh
+++ b/apps/agent-provisioning/AFJ/scripts/docker_start_agent.sh
@@ -205,7 +205,10 @@ if [ $? -eq 0 ]; then
 
     n=0
     agent_ready=false
-    until [ "$n" -ge 6 ]; do
+    AGENT_READINESS_MAX_ATTEMPTS="${AGENT_READINESS_MAX_ATTEMPTS:-20}"
+    AGENT_READINESS_RETRY_INTERVAL_SECONDS="${AGENT_READINESS_RETRY_INTERVAL_SECONDS:-10}"
+    until [ "$n" -ge "$AGENT_READINESS_MAX_ATTEMPTS" ]; do
+      # Linux-only: this provisioning path runs in Linux Docker/ECS environments.
       if netstat -tln | grep -E ":${ADMIN_PORT}[[:space:]]" >/dev/null; then
 
         AGENTURL="http://${EXTERNAL_IP}:${ADMIN_PORT}/health"
@@ -218,12 +221,12 @@ if [ $? -eq 0 ]; then
         else
           echo "Agent is not running"
           n=$((n + 1))
-          sleep 10
+          sleep "$AGENT_READINESS_RETRY_INTERVAL_SECONDS"
         fi
       else
         echo "No response from agent"
         n=$((n + 1))
-        sleep 10
+        sleep "$AGENT_READINESS_RETRY_INTERVAL_SECONDS"
       fi
     done
 

--- a/apps/agent-provisioning/AFJ/scripts/docker_start_agent.sh
+++ b/apps/agent-provisioning/AFJ/scripts/docker_start_agent.sh
@@ -204,14 +204,17 @@ if [ $? -eq 0 ]; then
   if [ $? -eq 0 ]; then
 
     n=0
+    agent_ready=false
     until [ "$n" -ge 6 ]; do
-      if netstat -tln | grep ${ADMIN_PORT} >/dev/null; then
+      if netstat -tln | grep -E ":${ADMIN_PORT}[[:space:]]" >/dev/null; then
 
         AGENTURL="http://${EXTERNAL_IP}:${ADMIN_PORT}/health"
-        agentResponse=$(curl -s -o /dev/null -w "%{http_code}" $AGENTURL)
+        agentResponse=$(curl -s -o /dev/null -w "%{http_code}" "$AGENTURL")
 
         if [ "$agentResponse" = "200" ]; then
-          echo "Agent is running" && break
+          echo "Agent is running"
+          agent_ready=true
+          break
         else
           echo "Agent is not running"
           n=$((n + 1))
@@ -223,6 +226,11 @@ if [ $? -eq 0 ]; then
         sleep 10
       fi
     done
+
+    if [ "$agent_ready" != "true" ]; then
+      echo "ERROR: Agent did not become ready within the retry budget"
+      exit 1
+    fi
 
     echo "Creating agent config"
  

--- a/apps/agent-provisioning/AFJ/scripts/docker_start_agent.sh
+++ b/apps/agent-provisioning/AFJ/scripts/docker_start_agent.sh
@@ -207,7 +207,7 @@ if [ $? -eq 0 ]; then
     until [ "$n" -ge 6 ]; do
       if netstat -tln | grep ${ADMIN_PORT} >/dev/null; then
 
-        AGENTURL="http://${EXTERNAL_IP}:${ADMIN_PORT}/agent"
+        AGENTURL="http://${EXTERNAL_IP}:${ADMIN_PORT}/health"
         agentResponse=$(curl -s -o /dev/null -w "%{http_code}" $AGENTURL)
 
         if [ "$agentResponse" = "200" ]; then

--- a/apps/agent-provisioning/AFJ/scripts/fargate.sh
+++ b/apps/agent-provisioning/AFJ/scripts/fargate.sh
@@ -318,7 +318,7 @@ if [ $? -eq 0 ]; then
   until [ "$n" -ge 20 ]; do
     if netstat -tln | grep ${ADMIN_PORT} >/dev/null; then
 
-      AGENTURL="http://${EXTERNAL_IP}:${ADMIN_PORT}/agent"
+      AGENTURL="http://${EXTERNAL_IP}:${ADMIN_PORT}/health"
       agentResponse=$(curl -s -o /dev/null -w "%{http_code}" $AGENTURL)
 
       if [ "$agentResponse" = "200" ]; then

--- a/apps/agent-provisioning/AFJ/scripts/fargate.sh
+++ b/apps/agent-provisioning/AFJ/scripts/fargate.sh
@@ -316,7 +316,10 @@ if [ $? -eq 0 ]; then
 
   n=0
   agent_ready=false
-  until [ "$n" -ge 20 ]; do
+  AGENT_READINESS_MAX_ATTEMPTS="${AGENT_READINESS_MAX_ATTEMPTS:-20}"
+  AGENT_READINESS_RETRY_INTERVAL_SECONDS="${AGENT_READINESS_RETRY_INTERVAL_SECONDS:-10}"
+  until [ "$n" -ge "$AGENT_READINESS_MAX_ATTEMPTS" ]; do
+    # Linux-only: this provisioning path runs in Linux Docker/ECS environments.
     if netstat -tln | grep -E ":${ADMIN_PORT}[[:space:]]" >/dev/null; then
 
       AGENTURL="http://${EXTERNAL_IP}:${ADMIN_PORT}/health"
@@ -329,12 +332,12 @@ if [ $? -eq 0 ]; then
       else
         echo "Agent is not running"
         n=$((n + 1))
-        sleep 10
+        sleep "$AGENT_READINESS_RETRY_INTERVAL_SECONDS"
       fi
     else
       echo "No response from agent"
       n=$((n + 1))
-      sleep 10
+      sleep "$AGENT_READINESS_RETRY_INTERVAL_SECONDS"
     fi
   done
 

--- a/apps/agent-provisioning/AFJ/scripts/fargate.sh
+++ b/apps/agent-provisioning/AFJ/scripts/fargate.sh
@@ -315,14 +315,17 @@ fi
 if [ $? -eq 0 ]; then
 
   n=0
+  agent_ready=false
   until [ "$n" -ge 20 ]; do
-    if netstat -tln | grep ${ADMIN_PORT} >/dev/null; then
+    if netstat -tln | grep -E ":${ADMIN_PORT}[[:space:]]" >/dev/null; then
 
       AGENTURL="http://${EXTERNAL_IP}:${ADMIN_PORT}/health"
-      agentResponse=$(curl -s -o /dev/null -w "%{http_code}" $AGENTURL)
+      agentResponse=$(curl -s -o /dev/null -w "%{http_code}" "$AGENTURL")
 
       if [ "$agentResponse" = "200" ]; then
-        echo "Agent is running" && break
+        echo "Agent is running"
+        agent_ready=true
+        break
       else
         echo "Agent is not running"
         n=$((n + 1))
@@ -334,6 +337,11 @@ if [ $? -eq 0 ]; then
       sleep 10
     fi
   done
+
+  if [ "$agent_ready" != "true" ]; then
+    echo "ERROR: Agent did not become ready within the retry budget"
+    exit 1
+  fi
 
 # Describe the ECS service and filter by service name
 service_description=$(aws ecs describe-services --service $SERVICE_NAME --cluster $CLUSTER_NAME --region $AWS_PUBLIC_REGION)

--- a/apps/agent-provisioning/AFJ/scripts/start_agent.sh
+++ b/apps/agent-provisioning/AFJ/scripts/start_agent.sh
@@ -218,7 +218,7 @@ if [ $? -eq 0 ]; then
     until [ "$n" -ge 6 ]; do
       if netstat -tln | grep ${ADMIN_PORT} >/dev/null; then
 
-        AGENTURL="http://${EXTERNAL_IP}:${ADMIN_PORT}/agent"
+        AGENTURL="http://${EXTERNAL_IP}:${ADMIN_PORT}/health"
         agentResponse=$(curl -s -o /dev/null -w "%{http_code}" $AGENTURL)
 
         if [ "$agentResponse" = "200" ]; then

--- a/apps/agent-provisioning/AFJ/scripts/start_agent.sh
+++ b/apps/agent-provisioning/AFJ/scripts/start_agent.sh
@@ -216,7 +216,10 @@ if [ $? -eq 0 ]; then
 
     n=0
     agent_ready=false
-    until [ "$n" -ge 6 ]; do
+    AGENT_READINESS_MAX_ATTEMPTS="${AGENT_READINESS_MAX_ATTEMPTS:-20}"
+    AGENT_READINESS_RETRY_INTERVAL_SECONDS="${AGENT_READINESS_RETRY_INTERVAL_SECONDS:-10}"
+    until [ "$n" -ge "$AGENT_READINESS_MAX_ATTEMPTS" ]; do
+      # Linux-only: this provisioning path runs in Linux Docker/ECS environments.
       if netstat -tln | grep -E ":${ADMIN_PORT}[[:space:]]" >/dev/null; then
 
         AGENTURL="http://${EXTERNAL_IP}:${ADMIN_PORT}/health"
@@ -229,12 +232,12 @@ if [ $? -eq 0 ]; then
         else
           echo "Agent is not running"
           n=$((n + 1))
-          sleep 10
+          sleep "$AGENT_READINESS_RETRY_INTERVAL_SECONDS"
         fi
       else
         echo "No response from agent"
         n=$((n + 1))
-        sleep 10
+        sleep "$AGENT_READINESS_RETRY_INTERVAL_SECONDS"
       fi
     done
 

--- a/apps/agent-provisioning/AFJ/scripts/start_agent.sh
+++ b/apps/agent-provisioning/AFJ/scripts/start_agent.sh
@@ -215,14 +215,17 @@ if [ $? -eq 0 ]; then
   if [ $? -eq 0 ]; then
 
     n=0
+    agent_ready=false
     until [ "$n" -ge 6 ]; do
-      if netstat -tln | grep ${ADMIN_PORT} >/dev/null; then
+      if netstat -tln | grep -E ":${ADMIN_PORT}[[:space:]]" >/dev/null; then
 
         AGENTURL="http://${EXTERNAL_IP}:${ADMIN_PORT}/health"
-        agentResponse=$(curl -s -o /dev/null -w "%{http_code}" $AGENTURL)
+        agentResponse=$(curl -s -o /dev/null -w "%{http_code}" "$AGENTURL")
 
         if [ "$agentResponse" = "200" ]; then
-          echo "Agent is running" && break
+          echo "Agent is running"
+          agent_ready=true
+          break
         else
           echo "Agent is not running"
           n=$((n + 1))
@@ -234,6 +237,11 @@ if [ $? -eq 0 ]; then
         sleep 10
       fi
     done
+
+    if [ "$agent_ready" != "true" ]; then
+      echo "ERROR: Agent did not become ready within the retry budget"
+      exit 1
+    fi
 
     echo "Creating agent config"
     # This is not actually being read, maybe we can remove this logic for endpoint file

--- a/apps/agent-provisioning/AFJ/scripts/start_agent_ecs.sh
+++ b/apps/agent-provisioning/AFJ/scripts/start_agent_ecs.sh
@@ -302,7 +302,10 @@ if [ $? -eq 0 ]; then
 
   n=0
   agent_ready=false
-  until [ "$n" -ge 20 ]; do
+  AGENT_READINESS_MAX_ATTEMPTS="${AGENT_READINESS_MAX_ATTEMPTS:-20}"
+  AGENT_READINESS_RETRY_INTERVAL_SECONDS="${AGENT_READINESS_RETRY_INTERVAL_SECONDS:-10}"
+  until [ "$n" -ge "$AGENT_READINESS_MAX_ATTEMPTS" ]; do
+    # Linux-only: this provisioning path runs in Linux Docker/ECS environments.
     if netstat -tln | grep -E ":${ADMIN_PORT}[[:space:]]" >/dev/null; then
 
       AGENTURL="http://${EXTERNAL_IP}:${ADMIN_PORT}/health"
@@ -315,12 +318,12 @@ if [ $? -eq 0 ]; then
       else
         echo "Agent is not running"
         n=$((n + 1))
-        sleep 10
+        sleep "$AGENT_READINESS_RETRY_INTERVAL_SECONDS"
       fi
     else
       echo "No response from agent"
       n=$((n + 1))
-      sleep 10
+      sleep "$AGENT_READINESS_RETRY_INTERVAL_SECONDS"
     fi
   done
 

--- a/apps/agent-provisioning/AFJ/scripts/start_agent_ecs.sh
+++ b/apps/agent-provisioning/AFJ/scripts/start_agent_ecs.sh
@@ -304,7 +304,7 @@ if [ $? -eq 0 ]; then
   until [ "$n" -ge 20 ]; do
     if netstat -tln | grep ${ADMIN_PORT} >/dev/null; then
 
-      AGENTURL="http://${EXTERNAL_IP}:${ADMIN_PORT}/agent"
+      AGENTURL="http://${EXTERNAL_IP}:${ADMIN_PORT}/health"
       agentResponse=$(curl -s -o /dev/null -w "%{http_code}" $AGENTURL)
 
       if [ "$agentResponse" = "200" ]; then

--- a/apps/agent-provisioning/AFJ/scripts/start_agent_ecs.sh
+++ b/apps/agent-provisioning/AFJ/scripts/start_agent_ecs.sh
@@ -301,14 +301,17 @@ fi
 if [ $? -eq 0 ]; then
 
   n=0
+  agent_ready=false
   until [ "$n" -ge 20 ]; do
-    if netstat -tln | grep ${ADMIN_PORT} >/dev/null; then
+    if netstat -tln | grep -E ":${ADMIN_PORT}[[:space:]]" >/dev/null; then
 
       AGENTURL="http://${EXTERNAL_IP}:${ADMIN_PORT}/health"
-      agentResponse=$(curl -s -o /dev/null -w "%{http_code}" $AGENTURL)
+      agentResponse=$(curl -s -o /dev/null -w "%{http_code}" "$AGENTURL")
 
       if [ "$agentResponse" = "200" ]; then
-        echo "Agent is running" && break
+        echo "Agent is running"
+        agent_ready=true
+        break
       else
         echo "Agent is not running"
         n=$((n + 1))
@@ -320,6 +323,11 @@ if [ $? -eq 0 ]; then
       sleep 10
     fi
   done
+
+  if [ "$agent_ready" != "true" ]; then
+    echo "ERROR: Agent did not become ready within the retry budget"
+    exit 1
+  fi
 
 # Describe the ECS service and filter by service name
 service_description=$(aws ecs describe-services --service $SERVICE_NAME --cluster $CLUSTER_NAME --region $AWS_PUBLIC_REGION)


### PR DESCRIPTION
Updates agent-provisioning scripts to poll the unauthenticated controller `/health` endpoint instead of authenticated `/agent`.

Provisioning succeeds only after an HTTP `200` response; it exits non-zero when the configured retry budget is exhausted. Requires agent-controller PR #77 to be merged and released before this platform change is deployed.