### PR TITLE
fix: run Prisma migrations only out of band

### DIFF
--- a/Dockerfiles/Dockerfile.agent-provisioning
+++ b/Dockerfiles/Dockerfile.agent-provisioning
@@ -30,7 +30,6 @@ RUN pnpm i --ignore-scripts
 COPY . .
 
 # Generate Prisma client
-# RUN cd libs/prisma-service && npx prisma migrate deploy && npx prisma generate
 RUN cd libs/prisma-service && npx prisma generate
 RUN ls -R /app/apps/agent-provisioning/AFJ/
 

--- a/Dockerfiles/Dockerfile.agent-provisioning
+++ b/Dockerfiles/Dockerfile.agent-provisioning
@@ -80,4 +80,4 @@ RUN chmod 777 /app/agent-provisioning/AFJ/token
 COPY libs/ ./libs/
 
 # Set the command to run the microservice
-CMD ["sh", "-c", "cd libs/prisma-service && npx prisma migrate deploy && npx prisma generate && cd ../.. && node dist/apps/agent-provisioning/main.js"]
+CMD ["node", "dist/apps/agent-provisioning/main.js"]

--- a/Dockerfiles/Dockerfile.agent-service
+++ b/Dockerfiles/Dockerfile.agent-service
@@ -33,4 +33,4 @@ COPY --from=build /app/dist/apps/agent-service/ ./dist/apps/agent-service/
 COPY --from=build /app/libs/ ./libs/
 COPY --from=build /app/node_modules ./node_modules
 USER nextjs
-CMD ["sh", "-c", "cd libs/prisma-service && npx prisma migrate deploy && cd ../.. && node dist/apps/agent-service/main.js"]
+CMD ["node", "dist/apps/agent-service/main.js"]

--- a/Dockerfiles/Dockerfile.api-gateway
+++ b/Dockerfiles/Dockerfile.api-gateway
@@ -23,4 +23,4 @@ COPY --from=build /app/dist/apps/api-gateway/ ./dist/apps/api-gateway/
 COPY --from=build /app/libs/ ./libs/
 COPY --from=build /app/node_modules ./node_modules
 USER nextjs
-CMD ["sh", "-c", "cd libs/prisma-service && npx prisma migrate deploy && cd ../.. && node dist/apps/api-gateway/main.js"]
+CMD ["node", "dist/apps/api-gateway/main.js"]

--- a/Dockerfiles/Dockerfile.cloud-wallet
+++ b/Dockerfiles/Dockerfile.cloud-wallet
@@ -23,4 +23,4 @@ COPY --from=build /app/dist/apps/cloud-wallet/ ./dist/apps/cloud-wallet/
 COPY --from=build /app/libs/ ./libs/
 COPY --from=build /app/node_modules ./node_modules
 USER nextjs
-CMD ["sh", "-c", "cd libs/prisma-service && npx prisma migrate deploy && cd ../.. && node dist/apps/cloud-wallet/main.js"]
+CMD ["node", "dist/apps/cloud-wallet/main.js"]

--- a/Dockerfiles/Dockerfile.connection
+++ b/Dockerfiles/Dockerfile.connection
@@ -23,4 +23,4 @@ COPY --from=build /app/dist/apps/connection/ ./dist/apps/connection/
 COPY --from=build /app/libs/ ./libs/
 COPY --from=build /app/node_modules ./node_modules
 USER nextjs
-CMD ["sh", "-c", "cd libs/prisma-service && npx prisma migrate deploy && cd ../.. && node dist/apps/connection/main.js"]
+CMD ["node", "dist/apps/connection/main.js"]

--- a/Dockerfiles/Dockerfile.ecosystem
+++ b/Dockerfiles/Dockerfile.ecosystem
@@ -23,4 +23,4 @@ COPY --from=build /app/dist/apps/ecosystem/ ./dist/apps/ecosystem/
 COPY --from=build /app/libs/ ./libs/
 COPY --from=build /app/node_modules ./node_modules
 USER nextjs
-CMD ["sh", "-c", "cd libs/prisma-service && npx prisma migrate deploy && cd ../.. && node dist/apps/ecosystem/main.js"]
+CMD ["node", "dist/apps/ecosystem/main.js"]

--- a/Dockerfiles/Dockerfile.geolocation
+++ b/Dockerfiles/Dockerfile.geolocation
@@ -23,4 +23,4 @@ COPY --from=build /app/dist/apps/geo-location/ ./dist/apps/geo-location/
 COPY --from=build /app/libs/ ./libs/
 COPY --from=build /app/node_modules ./node_modules
 USER nextjs
-CMD ["sh", "-c", "cd libs/prisma-service && npx prisma migrate deploy && cd ../.. && node dist/apps/geo-location/main.js"]
+CMD ["node", "dist/apps/geo-location/main.js"]

--- a/Dockerfiles/Dockerfile.issuance
+++ b/Dockerfiles/Dockerfile.issuance
@@ -24,4 +24,4 @@ COPY --from=build /app/libs/ ./libs/
 COPY --from=build /app/node_modules ./node_modules
 RUN mkdir -p /app/uploadedFiles/exports && chown -R nextjs:nodejs /app/uploadedFiles && chmod -R 775 /app/uploadedFiles
 USER nextjs
-CMD ["sh", "-c", "cd libs/prisma-service && npx prisma migrate deploy && cd ../.. && node dist/apps/issuance/main.js"]
+CMD ["node", "dist/apps/issuance/main.js"]

--- a/Dockerfiles/Dockerfile.ledger
+++ b/Dockerfiles/Dockerfile.ledger
@@ -23,4 +23,4 @@ COPY --from=build /app/dist/apps/ledger/ ./dist/apps/ledger/
 COPY --from=build /app/libs/ ./libs/
 COPY --from=build /app/node_modules ./node_modules
 USER nextjs
-CMD ["sh", "-c", "cd libs/prisma-service && npx prisma migrate deploy && cd ../.. && node dist/apps/ledger/main.js"]
+CMD ["node", "dist/apps/ledger/main.js"]

--- a/Dockerfiles/Dockerfile.marketplace
+++ b/Dockerfiles/Dockerfile.marketplace
@@ -24,4 +24,4 @@ COPY --from=build /app/libs/ ./libs/
 COPY --from=build /app/node_modules ./node_modules
 USER nextjs
 
-CMD ["sh", "-c", "cd libs/prisma-service && npx prisma migrate deploy && cd ../.. && node dist/apps/marketplace/main.js"]
+CMD ["node", "dist/apps/marketplace/main.js"]

--- a/Dockerfiles/Dockerfile.notification
+++ b/Dockerfiles/Dockerfile.notification
@@ -22,4 +22,4 @@ COPY --from=build /app/dist/apps/notification/ ./dist/apps/notification/
 COPY --from=build /app/libs/ ./libs/
 COPY --from=build /app/node_modules ./node_modules
 USER nextjs
-CMD ["sh", "-c", "cd libs/prisma-service && npx prisma migrate deploy && cd ../.. && node dist/apps/notification/main.js"]
+CMD ["node", "dist/apps/notification/main.js"]

--- a/Dockerfiles/Dockerfile.oid4vc-issuance
+++ b/Dockerfiles/Dockerfile.oid4vc-issuance
@@ -22,4 +22,4 @@ COPY --from=build /app/dist/apps/oid4vc-issuance/ ./dist/apps/oid4vc-issuance/
 COPY --from=build /app/libs/ ./libs/
 COPY --from=build /app/node_modules ./node_modules
 USER nextjs
-CMD ["sh", "-c", "cd libs/prisma-service && npx prisma migrate deploy && cd ../.. && node dist/apps/oid4vc-issuance/main.js"]
+CMD ["node", "dist/apps/oid4vc-issuance/main.js"]

--- a/Dockerfiles/Dockerfile.oid4vc-verification
+++ b/Dockerfiles/Dockerfile.oid4vc-verification
@@ -23,4 +23,4 @@ COPY --from=build /app/dist/apps/oid4vc-verification/ ./dist/apps/oid4vc-verific
 COPY --from=build /app/libs/ ./libs/
 COPY --from=build /app/node_modules ./node_modules
 USER nextjs
-CMD ["sh", "-c", "cd libs/prisma-service && npx prisma migrate deploy && cd ../.. && node dist/apps/oid4vc-verification/main.js"]
+CMD ["node", "dist/apps/oid4vc-verification/main.js"]

--- a/Dockerfiles/Dockerfile.organization
+++ b/Dockerfiles/Dockerfile.organization
@@ -23,4 +23,4 @@ COPY --from=build /app/dist/apps/organization/ ./dist/apps/organization/
 COPY --from=build /app/libs/ ./libs/
 COPY --from=build /app/node_modules ./node_modules
 USER nextjs
-CMD ["sh", "-c", "cd libs/prisma-service && npx prisma migrate deploy && cd ../.. && node dist/apps/organization/main.js"]
+CMD ["node", "dist/apps/organization/main.js"]

--- a/Dockerfiles/Dockerfile.seed
+++ b/Dockerfiles/Dockerfile.seed
@@ -13,4 +13,4 @@ RUN pnpm i --frozen-lockfile --ignore-scripts \
     && cd libs/prisma-service && npx prisma generate \
     && chown -R nextjs:nodejs /app
 USER nextjs
-CMD ["sh", "-c", "cd libs/prisma-service && npx prisma migrate deploy && cd ../.. && npx prisma db seed --schema=libs/prisma-service/prisma/schema.prisma"]
+CMD ["npx", "prisma", "db", "seed", "--schema=libs/prisma-service/prisma/schema.prisma"]

--- a/Dockerfiles/Dockerfile.user
+++ b/Dockerfiles/Dockerfile.user
@@ -23,4 +23,4 @@ COPY --from=build /app/dist/apps/user/ ./dist/apps/user/
 COPY --from=build /app/libs/ ./libs/
 COPY --from=build /app/node_modules ./node_modules
 USER nextjs
-CMD ["sh", "-c", "cd libs/prisma-service && npx prisma migrate deploy && cd ../.. && node dist/apps/user/main.js"]
+CMD ["node", "dist/apps/user/main.js"]

--- a/Dockerfiles/Dockerfile.utility
+++ b/Dockerfiles/Dockerfile.utility
@@ -23,4 +23,4 @@ COPY --from=build /app/dist/apps/utility/ ./dist/apps/utility/
 COPY --from=build /app/libs/ ./libs/
 COPY --from=build /app/node_modules ./node_modules
 USER nextjs
-CMD ["sh", "-c", "cd libs/prisma-service && npx prisma migrate deploy && cd ../.. && node dist/apps/utility/main.js"]
+CMD ["node", "dist/apps/utility/main.js"]

--- a/Dockerfiles/Dockerfile.verification
+++ b/Dockerfiles/Dockerfile.verification
@@ -23,4 +23,4 @@ COPY --from=build /app/dist/apps/verification/ ./dist/apps/verification/
 COPY --from=build /app/libs/ ./libs/
 COPY --from=build /app/node_modules ./node_modules
 USER nextjs
-CMD ["sh", "-c", "cd libs/prisma-service && npx prisma migrate deploy && cd ../.. && node dist/apps/verification/main.js"]
+CMD ["node", "dist/apps/verification/main.js"]

--- a/Dockerfiles/Dockerfile.webhook
+++ b/Dockerfiles/Dockerfile.webhook
@@ -23,4 +23,4 @@ COPY --from=build /app/dist/apps/webhook/ ./dist/apps/webhook/
 COPY --from=build /app/libs/ ./libs/
 COPY --from=build /app/node_modules ./node_modules
 USER nextjs
-CMD ["sh", "-c", "cd libs/prisma-service && npx prisma migrate deploy && cd ../.. && node dist/apps/webhook/main.js"]
+CMD ["node", "dist/apps/webhook/main.js"]

--- a/Dockerfiles/Dockerfile.x509
+++ b/Dockerfiles/Dockerfile.x509
@@ -23,4 +23,4 @@ COPY --from=build /app/dist/apps/x509/ ./dist/apps/x509/
 COPY --from=build /app/libs/ ./libs/
 COPY --from=build /app/node_modules ./node_modules
 USER nextjs
-CMD ["sh", "-c", "cd libs/prisma-service && npx prisma migrate deploy && cd ../.. && node dist/apps/x509/main.js"]
+CMD ["node", "dist/apps/x509/main.js"]


### PR DESCRIPTION
## Summary

Removes `prisma migrate deploy` from individual service and seed container startup commands.

Each container now starts only its intended service or seed command. Prisma migrations should be executed separately as an out-of-band deployment step.

## Changes

- Updated service Dockerfiles to start directly with `node dist/apps/<service>/main.js`
- Updated the agent-provisioning container to start directly without running migrations or Prisma generate
- Updated the seed container to run only `prisma db seed`

## Validation

- Verified all 20 Dockerfiles were updated
- Ran `git diff --check`